### PR TITLE
fix(pwa): fix installed PWA icon and remove desktop install banner

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:indigo_insights/router.dart';
 import 'package:indigo_insights/service_locator.dart';
 import 'package:indigo_insights/theme/app_theme.dart';
 import 'package:indigo_insights/theme/schemes/dark_scheme.dart';
-import 'package:indigo_insights/widgets/pwa_install_banner.dart';
 
 void main() async {
   setupServiceLocator();
@@ -20,7 +19,6 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       theme: AppTheme.build(darkScheme, darkStyles),
       routerConfig: appRouter,
-      builder: (context, child) => PwaInstallBanner(child: child ?? const SizedBox()),
     );
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -38,7 +38,7 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="indigo_insights">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+  <link rel="apple-touch-icon" href="icons/Icon-square-512.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -3,21 +3,24 @@
     "short_name": "Indigo Insights",
     "start_url": ".",
     "display": "standalone",
-    "background_color": "#272860",
-    "theme_color": "#272860",
-    "description": "Indigo Insights made for the Indigo community made by PWG.",
-    "orientation": "portrait-primary",
+    "display_override": ["standalone", "minimal-ui"],
+    "background_color": "#0E0E1A",
+    "theme_color": "#9945FF",
+    "description": "Protocol analytics dashboard for the Indigo community.",
+    "orientation": "any",
     "prefer_related_applications": false,
     "icons": [
         {
-            "src": "icons/Icon-192.png",
+            "src": "icons/Icon-square-512.png",
             "sizes": "192x192",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any"
         },
         {
-            "src": "icons/Icon-512.png",
+            "src": "icons/Icon-square-512.png",
             "sizes": "512x512",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any"
         },
         {
             "src": "icons/Icon-maskable-192.png",


### PR DESCRIPTION
## Summary

- **PWA icon fix** — `web/manifest.json` now points both non-maskable icon entries to `Icon-square-512.png` (the real app icon already in `web/icons/`) instead of the generic Flutter placeholder `Icon-192.png` / `Icon-512.png`. Browsers scale the 512px source to any needed size.
- **Manifest polish** — `theme_color` updated to `#9945FF` (iSOL purple) so the browser chrome matches the app on Android; `background_color` updated to `#0E0E1A` (dark canvas) for the splash screen; `orientation` changed to `any`; added `display_override` for broader browser PWA support.
- **iOS icon** — `apple-touch-icon` in `index.html` updated to `Icon-square-512.png` (used by iOS Add to Home Screen).
- **Remove desktop PWA banner** — `PwaInstallBanner` wrapper removed from `main.dart`; the mobile "Install App" button in `IITopBar` is the sole install entry point.

## Test plan
- [ ] Install as PWA on Android Chrome — home screen icon should show the Indigo Insights logo
- [ ] Install as PWA on iOS Safari (Add to Home Screen) — same
- [ ] Desktop: confirm the slide-up install banner no longer appears