### PR TITLE
fix(ui): enforce canonical iAsset order (iUSD → iBTC → iETH → iSOL)

### DIFF
--- a/lib/utils/formatters.dart
+++ b/lib/utils/formatters.dart
@@ -51,3 +51,19 @@ String numberAbbreviatedFormatter(
       return number.toStringAsFixed(2);
   }
 }
+
+/// Canonical display order for Indigo iAssets.
+const _kAssetOrder = ['iUSD', 'iBTC', 'iETH', 'iSOL'];
+
+int assetSortIndex(String asset) {
+  final i = _kAssetOrder.indexOf(asset);
+  return i >= 0 ? i : _kAssetOrder.length;
+}
+
+/// Sort a list of objects that expose an [asset] name by canonical order.
+List<T> sortedByAsset<T>(List<T> items, String Function(T) getName) {
+  final copy = List<T>.from(items);
+  copy.sort((a, b) => assetSortIndex(getName(a))
+      .compareTo(assetSortIndex(getName(b))));
+  return copy;
+}

--- a/lib/views/insights/dashboard/protocol_dashboard.dart
+++ b/lib/views/insights/dashboard/protocol_dashboard.dart
@@ -137,7 +137,7 @@ class _TvlByAssetSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final styles = AppTextStyles.of(context);
     final colors = AppColorScheme.of(context);
-    final statuses = data.assetStatuses;
+    final statuses = sortedByAsset(data.assetStatuses, (s) => s.asset);
     final maxTvl = statuses.isEmpty
         ? 1.0
         : statuses.map((s) => s.totalValueLocked).reduce((a, b) => a > b ? a : b);
@@ -381,7 +381,7 @@ class _AssetHealthSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDesktop = MediaQuery.of(context).size.width >= 700;
 
-    final cards = data.assetStatuses.mapIndexed((i, status) {
+    final cards = sortedByAsset(data.assetStatuses, (s) => s.asset).mapIndexed((i, status) {
       final pool = data.stabilityPools
           .firstWhereOrNull((p) => p.asset == status.asset);
       final assetCdps =

--- a/lib/widgets/ii_asset_tabs.dart
+++ b/lib/widgets/ii_asset_tabs.dart
@@ -4,6 +4,7 @@ import 'package:indigo_insights/repositories/indigo_asset_repository.dart';
 import 'package:indigo_insights/router.dart';
 import 'package:indigo_insights/service_locator.dart';
 import 'package:indigo_insights/utils/async_builder.dart';
+import 'package:indigo_insights/utils/formatters.dart';
 import 'package:indigo_insights/widgets/ii_tab_bar.dart';
 
 /// iAsset tab bar that fetches assets from the repository and renders an
@@ -55,7 +56,9 @@ class _IIAssetTabsState extends State<IIAssetTabs>
   @override
   Widget build(BuildContext context) {
     return AsyncBuilder<List<IndigoAsset>>(
-      fetcher: () => sl<IndigoAssetRepository>().getAssets(),
+      fetcher: () => sl<IndigoAssetRepository>().getAssets().then(
+            (list) => sortedByAsset(list, (a) => a.asset),
+          ),
       builder: (assets) {
         _lastAssetNames = assets.map((a) => a.asset).toList();
         if (_controller == null || _controller!.length != assets.length) {


### PR DESCRIPTION
## Summary

- Assets were displayed in the order returned by the API, which is arbitrary and inconsistent
- Add a `sortedByAsset<T>()` helper in `lib/utils/formatters.dart` with canonical order `['iUSD', 'iBTC', 'iETH', 'iSOL']` (unknown assets fall to the end)
- Apply sorting to `_TvlByAssetSection` and `_AssetHealthSection` on the Protocol Dashboard
- Apply sorting to `IIAssetTabs`, the shared tab bar used across all asset pages (CDP Explorer, Stability Pool, etc.)

## Test plan

- [ ] Open the Protocol Dashboard — TVL bars and Asset Health cards appear in iUSD → iBTC → iETH → iSOL order
- [ ] Open any page with iAsset tabs — tabs follow the same canonical order