### PR TITLE
ci: add Release APK workflow + fix README download link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: pubspec.yaml
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Rename APK
+        run: mv build/app/outputs/flutter-apk/app-release.apk indigo-insights-${{ github.ref_name }}.apk
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Indigo Insights ${{ github.ref_name }}
+          body: |
+            ## Indigo Insights ${{ github.ref_name }}
+
+            Protocol analytics dashboard for the Indigo community.
+
+            ### Install on Android
+            Download and install `indigo-insights-${{ github.ref_name }}.apk` on your Android device.
+            You may need to allow installation from unknown sources in your device settings.
+
+            ### Web App
+            🌐 [Open Web App](https://nyorok.github.io/IndigoInsights)
+          files: indigo-insights-${{ github.ref_name }}.apk
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > Protocol analytics dashboard for the [Indigo Protocol](https://indigoprotocol.io) community, built with Flutter — available as a **web app**, **Android APK**, and **PWA**.
 
-**[🌐 Open Web App](https://nyorok.github.io/IndigoInsights)** &nbsp;|&nbsp; **[📦 Download APK](https://github.com/nyorok/IndigoInsights/tree/main/release)**
+**[🌐 Open Web App](https://nyorok.github.io/IndigoInsights)** &nbsp;|&nbsp; **[📦 Download APK](https://github.com/nyorok/IndigoInsights/releases/latest)**
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml`: triggers on `v*` tags, builds the APK with Flutter, and publishes a GitHub Release with the APK attached
- Update README `Download APK` link from the old `tree/main/release` path to `releases/latest` so it always points to the newest release

## How to use after merge

1. Merge this PR
2. Push a version tag: `git tag v1.0.0 && git push origin v1.0.0`
3. The workflow builds the APK on GitHub Actions and creates a release at `https://github.com/nyorok/IndigoInsights/releases/latest`

## Test plan

- [ ] Merge and push `v1.0.0` tag
- [ ] Confirm GitHub Actions `Release APK` workflow completes successfully
- [ ] Confirm release appears at `https://github.com/nyorok/IndigoInsights/releases/latest` with the APK attached
- [ ] Confirm README download link resolves to the release page