### PR TITLE
feat(v3): multi collateral compatibility and new iAssets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Flutter analytics dashboard for Indigo Protocol (Cardano DeFi). Read-only; no wa
 
 ## Tech Stack
 
-- Flutter 3.41.5 / Dart SDK ^3.11.0
+- Flutter 3.41.9 / Dart SDK ^3.11.0
 - DI / State: `get_it` (service locator) + `FutureBuilder` via `AsyncBuilder`
 - Charts: `fl_chart`
 - HTTP: `package:http`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Indigo Insights
 
 [![Deploy Web App to GitHub Pages](https://github.com/nyorok/IndigoInsights/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/nyorok/IndigoInsights/actions/workflows/deploy.yml)
-[![Flutter](https://img.shields.io/badge/Flutter-3.41.5-blue?logo=flutter)](https://flutter.dev)
+[![Flutter](https://img.shields.io/badge/Flutter-3.41.9-blue?logo=flutter)](https://flutter.dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-purple)](LICENSE)
 
 > Protocol analytics dashboard for the [Indigo Protocol](https://indigoprotocol.io) community, built with Flutter — available as a **web app**, **Android APK**, and **PWA**.
@@ -48,7 +48,7 @@ Stability pool account distribution and unclaimed rewards visualised as pie char
 
 | Layer | Library |
 |---|---|
-| Framework | Flutter 3.41.5 / Dart 3.x |
+| Framework | Flutter 3.41.9 / Dart 3.x |
 | Routing | `go_router` — URL-based navigation with tab-level deep links (e.g. `/#/cdp-explorer?tab=iUSD`) |
 | State / DI | `get_it` — service locator + repository pattern |
 | Charts | `fl_chart` |
@@ -131,7 +131,7 @@ Every page and tab is directly addressable:
 ## Getting Started
 
 ### Prerequisites
-- Flutter `3.41.5` (or compatible `>=3.29.0`)
+- Flutter `3.41.9` (or compatible `>=3.29.0`)
 - Dart `>=3.11.0`
 
 ### Run locally

--- a/lib/api/indigo_api/services/apr_service.dart
+++ b/lib/api/indigo_api/services/apr_service.dart
@@ -1,0 +1,7 @@
+import 'package:indigo_insights/api/indigo_api/indigo_api.dart';
+import 'package:indigo_insights/models/apr_entry.dart';
+
+class AprService extends IndigoApi {
+  Future<List<AprEntry>> fetchAprs() =>
+      getAll('/api/v3/apr', AprEntry.fromJson);
+}

--- a/lib/api/indigo_api/services/indigo_asset_service.dart
+++ b/lib/api/indigo_api/services/indigo_asset_service.dart
@@ -3,6 +3,6 @@ import 'package:indigo_insights/models/indigo_asset.dart';
 
 class IndigoAssetService extends IndigoApi {
   Future<List<IndigoAsset>> fetchIndigoAssets() {
-    return getAll<IndigoAsset>('/api/assets', IndigoAsset.fromJson);
+    return getAll<IndigoAsset>('/api/v3/assets', IndigoAsset.fromJson);
   }
 }

--- a/lib/models/apr_entry.dart
+++ b/lib/models/apr_entry.dart
@@ -1,0 +1,11 @@
+class AprEntry {
+  final String key;
+  final double value;
+
+  AprEntry({required this.key, required this.value});
+
+  factory AprEntry.fromJson(Map<String, dynamic> json) => AprEntry(
+    key: json['key'] as String,
+    value: (json['value'] as num).toDouble(),
+  );
+}

--- a/lib/models/asset_interest_rate.dart
+++ b/lib/models/asset_interest_rate.dart
@@ -1,10 +1,12 @@
 class AssetInterestRate {
   final String asset;
+  final String collateralAsset; // V3: per-collateral interest oracle
   final double interestRate;
   final int slot;
 
   AssetInterestRate({
     required this.asset,
+    this.collateralAsset = '',
     required this.interestRate,
     required this.slot,
   });
@@ -12,12 +14,17 @@ class AssetInterestRate {
   factory AssetInterestRate.fromJson(Map<String, dynamic> json) {
     return AssetInterestRate(
       asset: json['asset'] as String,
+      collateralAsset: (json['collateral_asset'] as String?) ?? '',
       interestRate: ((json['interest_rate'] as int?) ?? 0) / 1000000,
       slot: json['slot'] as int,
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {'asset': asset, 'interestRate': interestRate};
+    return {
+      'asset': asset,
+      'collateral_asset': collateralAsset,
+      'interestRate': interestRate,
+    };
   }
 }

--- a/lib/models/asset_price.dart
+++ b/lib/models/asset_price.dart
@@ -1,14 +1,19 @@
 class AssetPrice {
   final String asset;
+  final String collateralAsset;
   final double price;
 
-  AssetPrice({required this.asset, required this.price});
+  AssetPrice({required this.asset, this.collateralAsset = '', required this.price});
 
   factory AssetPrice.fromJson(Map<String, dynamic> json) {
-    return AssetPrice(asset: json['asset'] as String, price: (json['price'] as num) / 1000000);
+    return AssetPrice(
+      asset: json['asset'] as String,
+      collateralAsset: (json['collateral_asset'] as String?) ?? '',
+      price: double.parse(json['price'] as String),
+    );
   }
 
   Map<String, dynamic> toJson() {
-    return {'asset': asset, 'price': price};
+    return {'asset': asset, 'collateral_asset': collateralAsset, 'price': price};
   }
 }

--- a/lib/models/cdp.dart
+++ b/lib/models/cdp.dart
@@ -1,37 +1,43 @@
 class Cdp {
   final String asset;
+  final String collateralAsset; // V3: which collateral backs this position
   final double collateralAmount;
   final double mintedAmount;
   final int outputIndex;
   final String outputHash;
   final String owner;
 
-  Cdp(
-      {required this.asset,
-      required this.collateralAmount,
-      required this.mintedAmount,
-      required this.outputIndex,
-      required this.outputHash,
-      required this.owner});
+  Cdp({
+    required this.asset,
+    this.collateralAsset = '',
+    required this.collateralAmount,
+    required this.mintedAmount,
+    required this.outputIndex,
+    required this.outputHash,
+    required this.owner,
+  });
 
   factory Cdp.fromJson(Map<String, dynamic> json) {
     return Cdp(
-        asset: json['asset'] as String,
-        collateralAmount: (json['collateralAmount'] as num) / 1000000,
-        mintedAmount: (json['mintedAmount'] as num) / 1000000,
-        outputIndex: json['output_index'] as int,
-        outputHash: (json['output_hash'] as String?) ?? '',
-        owner: (json['owner'] as String?) ?? '');
+      asset: json['asset'] as String,
+      collateralAsset: (json['collateral_asset'] as String?) ?? '',
+      collateralAmount: (json['collateralAmount'] as num) / 1000000,
+      mintedAmount: (json['mintedAmount'] as num) / 1000000,
+      outputIndex: json['output_index'] as int,
+      outputHash: (json['output_hash'] as String?) ?? '',
+      owner: (json['owner'] as String?) ?? '',
+    );
   }
 
   Map<String, dynamic> toJson() {
     return {
       'asset': asset,
+      'collateral_asset': collateralAsset,
       'collateralAmount': collateralAmount,
       'mintedAmount': mintedAmount,
       'output_index': outputIndex,
       'output_hash': outputHash,
-      'owner': owner
+      'owner': owner,
     };
   }
 }

--- a/lib/models/collateral_pair.dart
+++ b/lib/models/collateral_pair.dart
@@ -1,0 +1,29 @@
+class CollateralPair {
+  final String collateralAsset; // empty = ADA
+  final double liquidationRatioPercent;
+  final double maintenanceRatioPercent;
+  final double redemptionRatioPercent;
+  final double interestRate;
+
+  CollateralPair({
+    required this.collateralAsset,
+    required this.liquidationRatioPercent,
+    required this.maintenanceRatioPercent,
+    required this.redemptionRatioPercent,
+    required this.interestRate,
+  });
+
+  factory CollateralPair.fromJson(Map<String, dynamic> json) => CollateralPair(
+    collateralAsset: (json['collateralAsset'] as String?) ?? '',
+    liquidationRatioPercent:
+        (json['liquidationRatioPercent'] as num?)?.toDouble() ?? 110.0,
+    maintenanceRatioPercent:
+        (json['maintenanceRatioPercent'] as num?)?.toDouble() ?? 115.0,
+    redemptionRatioPercent:
+        (json['redemptionRatioPercent'] as num?)?.toDouble() ?? 150.0,
+    interestRate:
+        ((json['interest'] as Map<String, dynamic>?)?['rate'] as num?)
+            ?.toDouble() ??
+        0.0,
+  );
+}

--- a/lib/models/indigo_asset.dart
+++ b/lib/models/indigo_asset.dart
@@ -1,22 +1,12 @@
+import 'package:collection/collection.dart';
+import 'package:indigo_insights/models/collateral_pair.dart';
+
 class IndigoAsset {
   final String asset;
-  final DateTime createdAt;
-  final double? delistPrice;
-  final String hash;
-  final String? oracleNftCs;
-  final String? oracleNftTn;
   final String outputHash;
   final int outputIndex;
-  final int slot;
-  final DateTime updatedAt;
+  final List<CollateralPair> collateralAssets;
 
-  // V3: these ratios live on the collateral pair, not the iAsset; null until a
-  // collateral endpoint is published.
-  final double? rmr;
-  final double? maintenanceRatio;
-  final double? liquidationRatio;
-
-  // V3: plain percentages (e.g. 0.1 = 0.1%), not micro-units.
   final double debtMintingFee;
   final double? liquidationProcessingFee;
   final double? stabilityPoolWithdrawalFee;
@@ -25,18 +15,9 @@ class IndigoAsset {
 
   IndigoAsset({
     required this.asset,
-    required this.createdAt,
-    this.delistPrice,
-    required this.hash,
-    this.oracleNftCs,
-    this.oracleNftTn,
     required this.outputHash,
     required this.outputIndex,
-    required this.slot,
-    required this.updatedAt,
-    this.rmr,
-    this.maintenanceRatio,
-    this.liquidationRatio,
+    required this.collateralAssets,
     required this.debtMintingFee,
     this.liquidationProcessingFee,
     this.stabilityPoolWithdrawalFee,
@@ -44,49 +25,49 @@ class IndigoAsset {
     this.redemptionReimbursementFee,
   });
 
+  // ADA-collateral pair preferred (empty collateralAsset), fallback to first.
+  CollateralPair? get _adaPair =>
+      collateralAssets.firstWhereOrNull((p) => p.collateralAsset.isEmpty) ??
+      collateralAssets.firstOrNull;
+
+  // Backwards-compatible single-value getters (ADA pair).
+  double? get liquidationRatio => _adaPair?.liquidationRatioPercent;
+  double? get maintenanceRatio => _adaPair?.maintenanceRatioPercent;
+  double? get rmr => _adaPair?.redemptionRatioPercent;
+
+  // Per-collateral lookups — O(n_pairs ≤ 3), safe everywhere.
+  double getLiquidationRatio(String collateralAsset) =>
+      collateralAssets
+          .firstWhereOrNull((p) => p.collateralAsset == collateralAsset)
+          ?.liquidationRatioPercent ??
+      110.0;
+
+  double getMaintenanceRatio(String collateralAsset) =>
+      collateralAssets
+          .firstWhereOrNull((p) => p.collateralAsset == collateralAsset)
+          ?.maintenanceRatioPercent ??
+      115.0;
+
   factory IndigoAsset.fromJson(Map<String, dynamic> json) {
-    double? _pct(String key) {
-      final v = json[key];
-      if (v == null) return null;
-      return (v as num).toDouble();
-    }
+    final pairs = (json['collateralAssets'] as List<dynamic>? ?? [])
+        .map((e) => CollateralPair.fromJson(e as Map<String, dynamic>))
+        .toList();
 
     return IndigoAsset(
-      asset: json['asset'] as String,
-      createdAt: DateTime.parse(json['created_at'] as String),
-      delistPrice: json['delist_price'] != null
-          ? double.parse(json['delist_price'] as String)
-          : null,
-      hash: json['hash'] as String,
-      oracleNftCs: json['oracle_nft_cs'] as String?,
-      oracleNftTn: json['oracle_nft_tn'] as String?,
-      outputHash: json['output_hash'] as String,
-      outputIndex: json['output_index'] as int,
-      slot: json['slot'] as int,
-      updatedAt: DateTime.parse(json['updated_at'] as String),
-      rmr: _pct('redemption_ratio_percentage'),
-      maintenanceRatio: _pct('maintenance_ratio_percentage'),
-      liquidationRatio: _pct('liquidation_ratio_percentage'),
-      debtMintingFee: _pct('debt_minting_fee_percentage') ?? 0.0,
-      liquidationProcessingFee: _pct('liquidation_processing_fee_percentage'),
-      stabilityPoolWithdrawalFee: _pct('stability_pool_withdrawal_fee_percentage'),
-      redemptionProcessingFee: _pct('redemption_processing_fee_percentage'),
-      redemptionReimbursementFee: _pct('redemption_reimbursement_percentage'),
+      asset: json['name'] as String,
+      outputHash: (json['outputHash'] as String?) ?? '',
+      outputIndex: (json['outputIndex'] as int?) ?? 0,
+      collateralAssets: pairs,
+      debtMintingFee:
+          (json['debtMintingFeePercent'] as num?)?.toDouble() ?? 0.0,
+      liquidationProcessingFee:
+          (json['liquidationProcessingFeePercent'] as num?)?.toDouble(),
+      stabilityPoolWithdrawalFee:
+          (json['stabilityPoolWithdrawalFeePercent'] as num?)?.toDouble(),
+      redemptionProcessingFee:
+          (json['redemptionProcessingFeePercent'] as num?)?.toDouble(),
+      redemptionReimbursementFee:
+          (json['redemptionReimbursementPercent'] as num?)?.toDouble(),
     );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'asset': asset,
-      'createdAt': createdAt.toIso8601String(),
-      'delist_price': delistPrice,
-      'hash': hash,
-      'oracle_nft_cs': oracleNftCs,
-      'oracle_nft_tn': oracleNftTn,
-      'output_hash': outputHash,
-      'output_index': outputIndex,
-      'slot': slot,
-      'updated_at': updatedAt.toIso8601String(),
-    };
   }
 }

--- a/lib/models/indigo_asset.dart
+++ b/lib/models/indigo_asset.dart
@@ -3,35 +3,54 @@ class IndigoAsset {
   final DateTime createdAt;
   final double? delistPrice;
   final String hash;
-  final String oracleNftCs;
-  final String oracleNftTn;
+  final String? oracleNftCs;
+  final String? oracleNftTn;
   final String outputHash;
   final int outputIndex;
   final int slot;
   final DateTime updatedAt;
-  final double rmr;
-  final double maintenanceRatio;
-  final double liquidationRatio;
+
+  // V3: these ratios live on the collateral pair, not the iAsset; null until a
+  // collateral endpoint is published.
+  final double? rmr;
+  final double? maintenanceRatio;
+  final double? liquidationRatio;
+
+  // V3: plain percentages (e.g. 0.1 = 0.1%), not micro-units.
   final double debtMintingFee;
+  final double? liquidationProcessingFee;
+  final double? stabilityPoolWithdrawalFee;
+  final double? redemptionProcessingFee;
+  final double? redemptionReimbursementFee;
 
   IndigoAsset({
     required this.asset,
     required this.createdAt,
     this.delistPrice,
     required this.hash,
-    required this.oracleNftCs,
-    required this.oracleNftTn,
+    this.oracleNftCs,
+    this.oracleNftTn,
     required this.outputHash,
     required this.outputIndex,
     required this.slot,
     required this.updatedAt,
-    required this.rmr,
-    required this.maintenanceRatio,
-    required this.liquidationRatio,
+    this.rmr,
+    this.maintenanceRatio,
+    this.liquidationRatio,
     required this.debtMintingFee,
+    this.liquidationProcessingFee,
+    this.stabilityPoolWithdrawalFee,
+    this.redemptionProcessingFee,
+    this.redemptionReimbursementFee,
   });
 
   factory IndigoAsset.fromJson(Map<String, dynamic> json) {
+    double? _pct(String key) {
+      final v = json[key];
+      if (v == null) return null;
+      return (v as num).toDouble();
+    }
+
     return IndigoAsset(
       asset: json['asset'] as String,
       createdAt: DateTime.parse(json['created_at'] as String),
@@ -39,34 +58,35 @@ class IndigoAsset {
           ? double.parse(json['delist_price'] as String)
           : null,
       hash: json['hash'] as String,
-      oracleNftCs: json['oracle_nft_cs'] as String,
-      oracleNftTn: json['oracle_nft_tn'] as String,
+      oracleNftCs: json['oracle_nft_cs'] as String?,
+      oracleNftTn: json['oracle_nft_tn'] as String?,
       outputHash: json['output_hash'] as String,
       outputIndex: json['output_index'] as int,
       slot: json['slot'] as int,
       updatedAt: DateTime.parse(json['updated_at'] as String),
-      rmr: (json['redemption_ratio_percentage'] as num).toDouble() / 1000000.0,
-      maintenanceRatio:
-          (json['maintenance_ratio_percentage'] as num).toDouble() / 1000000.0,
-      liquidationRatio:
-          (json['liquidation_ratio_percentage'] as num).toDouble() / 1000000.0,
-      debtMintingFee:
-          (json['debt_minting_fee_percentage'] as num).toDouble() / 1000000.0,
+      rmr: _pct('redemption_ratio_percentage'),
+      maintenanceRatio: _pct('maintenance_ratio_percentage'),
+      liquidationRatio: _pct('liquidation_ratio_percentage'),
+      debtMintingFee: _pct('debt_minting_fee_percentage') ?? 0.0,
+      liquidationProcessingFee: _pct('liquidation_processing_fee_percentage'),
+      stabilityPoolWithdrawalFee: _pct('stability_pool_withdrawal_fee_percentage'),
+      redemptionProcessingFee: _pct('redemption_processing_fee_percentage'),
+      redemptionReimbursementFee: _pct('redemption_reimbursement_percentage'),
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
       'asset': asset,
-      'createdAt': createdAt,
+      'createdAt': createdAt.toIso8601String(),
       'delist_price': delistPrice,
       'hash': hash,
       'oracle_nft_cs': oracleNftCs,
-      'oracle_nft_tn': oracleNftCs,
+      'oracle_nft_tn': oracleNftTn,
       'output_hash': outputHash,
       'output_index': outputIndex,
       'slot': slot,
-      'updated_at': updatedAt,
+      'updated_at': updatedAt.toIso8601String(),
     };
   }
 }

--- a/lib/models/liquidation.dart
+++ b/lib/models/liquidation.dart
@@ -1,40 +1,63 @@
 class Liquidation {
-  final double adaPrice;
+  // V3: renamed from ada_price → collateral_asset_usd_price; now a num (not string)
+  final double collateralUsdPrice;
   final String asset;
+  final String collateralAsset;
   final double collateralAbsorbed;
   final DateTime createdAt;
   final double iAssetBurned;
   final int id;
-  final double oraclePrice;
+  final double? oraclePrice; // absent on recent V3 liquidations
   final String outputHash;
   final int outputIndex;
   final int slot;
   final DateTime updatedAt;
 
-  Liquidation(
-      {required this.adaPrice,
-      required this.asset,
-      required this.collateralAbsorbed,
-      required this.createdAt,
-      required this.iAssetBurned,
-      required this.id,
-      required this.oraclePrice,
-      required this.outputHash,
-      required this.outputIndex,
-      required this.slot,
-      required this.updatedAt});
+  Liquidation({
+    required this.collateralUsdPrice,
+    required this.asset,
+    this.collateralAsset = '',
+    required this.collateralAbsorbed,
+    required this.createdAt,
+    required this.iAssetBurned,
+    required this.id,
+    this.oraclePrice,
+    required this.outputHash,
+    required this.outputIndex,
+    required this.slot,
+    required this.updatedAt,
+  });
+
+  // Back-compat getter used by existing callers expecting ada_price
+  double get adaPrice => collateralUsdPrice;
 
   factory Liquidation.fromJson(Map<String, dynamic> json) {
+    double _parseUsdPrice() {
+      final v3 = json['collateral_asset_usd_price'];
+      if (v3 != null) return (v3 as num).toDouble();
+      // V2 fallback
+      final v2 = json['ada_price'];
+      if (v2 != null) return double.parse(v2 as String);
+      return 0.0;
+    }
+
+    double? _parseOraclePrice() {
+      final v = json['oracle_price'];
+      if (v == null) return null;
+      return double.parse(v as String);
+    }
+
     return Liquidation(
-      adaPrice: double.parse(json['ada_price'] as String),
+      collateralUsdPrice: _parseUsdPrice(),
       asset: json['asset'] as String,
+      collateralAsset: (json['collateral_asset'] as String?) ?? '',
       collateralAbsorbed: (json['collateral_absorbed'] as num) / 1000000,
       createdAt: DateTime.parse(json['created_at'] as String),
       iAssetBurned: (json['iasset_burned'] as num) / 1000000,
       id: json['id'] as int,
-      oraclePrice: double.parse(json['oracle_price'] as String),
-      outputHash: json['output_hash'] as String,
-      outputIndex: json['output_index'] as int,
+      oraclePrice: _parseOraclePrice(),
+      outputHash: (json['output_hash'] as String?) ?? '',
+      outputIndex: (json['output_index'] as int?) ?? 0,
       slot: json['slot'] as int,
       updatedAt: DateTime.parse(json['updated_at'] as String),
     );
@@ -42,17 +65,18 @@ class Liquidation {
 
   Map<String, dynamic> toJson() {
     return {
-      'ada_price': adaPrice,
+      'collateral_asset_usd_price': collateralUsdPrice,
       'asset': asset,
+      'collateral_asset': collateralAsset,
       'collateral_absorbed': collateralAbsorbed,
-      'created_at': createdAt,
+      'created_at': createdAt.toIso8601String(),
       'iasset_burned': iAssetBurned,
       'id': id,
       'oracle_price': oraclePrice,
       'output_hash': outputHash,
       'output_index': outputIndex,
       'slot': slot,
-      'updated_at': updatedAt,
+      'updated_at': updatedAt.toIso8601String(),
     };
   }
 }

--- a/lib/models/liquidation.dart
+++ b/lib/models/liquidation.dart
@@ -32,7 +32,7 @@ class Liquidation {
   double get adaPrice => collateralUsdPrice;
 
   factory Liquidation.fromJson(Map<String, dynamic> json) {
-    double _parseUsdPrice() {
+    double parseUsdPrice() {
       final v3 = json['collateral_asset_usd_price'];
       if (v3 != null) return (v3 as num).toDouble();
       // V2 fallback
@@ -41,21 +41,21 @@ class Liquidation {
       return 0.0;
     }
 
-    double? _parseOraclePrice() {
+    double? parseOraclePrice() {
       final v = json['oracle_price'];
       if (v == null) return null;
       return double.parse(v as String);
     }
 
     return Liquidation(
-      collateralUsdPrice: _parseUsdPrice(),
+      collateralUsdPrice: parseUsdPrice(),
       asset: json['asset'] as String,
       collateralAsset: (json['collateral_asset'] as String?) ?? '',
       collateralAbsorbed: (json['collateral_absorbed'] as num) / 1000000,
       createdAt: DateTime.parse(json['created_at'] as String),
       iAssetBurned: (json['iasset_burned'] as num) / 1000000,
       id: json['id'] as int,
-      oraclePrice: _parseOraclePrice(),
+      oraclePrice: parseOraclePrice(),
       outputHash: (json['output_hash'] as String?) ?? '',
       outputIndex: (json['output_index'] as int?) ?? 0,
       slot: json['slot'] as int,

--- a/lib/models/stability_pool.dart
+++ b/lib/models/stability_pool.dart
@@ -21,9 +21,10 @@ class SpAssetState {
     final Map<String, BigInt> etsMap = {};
     if (rawEts is List) {
       for (final entry in rawEts) {
-        final epoch = entry['epoch'] as String;
-        final scale = entry['scale'] as String;
-        final val = entry['sumVal'] as String;
+        final row = entry as Map<String, dynamic>;
+        final epoch = row['epoch'] as String;
+        final scale = row['scale'] as String;
+        final val = row['sumVal'] as String;
         etsMap['$epoch,$scale'] = BigInt.parse(val);
       }
     }
@@ -65,7 +66,7 @@ class StabilityPool {
   });
 
   factory StabilityPool.fromJson(Map<String, dynamic> json) {
-    Map<String, BigInt> parsedEts = {};
+    final Map<String, BigInt> parsedEts = {};
     final rawEts = json['epoch_to_scale_to_sum'];
     if (rawEts is String) {
       final decoded = jsonDecode(rawEts) as Map<String, dynamic>;

--- a/lib/models/stability_pool.dart
+++ b/lib/models/stability_pool.dart
@@ -4,77 +4,125 @@ import 'package:indigo_insights/models/stability_pool_account.dart';
 
 BigInt conversionValue = BigInt.from(10).pow(24);
 
-// Documentation about each property
+// V3: per-collateral reward stream inside asset_states
+class SpAssetState {
+  final String collateralAsset;
+  final BigInt sumVal;
+  final Map<String, BigInt> epochToScaleToSum;
+
+  SpAssetState({
+    required this.collateralAsset,
+    required this.sumVal,
+    required this.epochToScaleToSum,
+  });
+
+  factory SpAssetState.fromJson(Map<String, dynamic> json) {
+    final rawEts = json['epochToScaleToSum'];
+    final Map<String, BigInt> etsMap = {};
+    if (rawEts is List) {
+      for (final entry in rawEts) {
+        final epoch = entry['epoch'] as String;
+        final scale = entry['scale'] as String;
+        final val = entry['sumVal'] as String;
+        etsMap['$epoch,$scale'] = BigInt.parse(val);
+      }
+    }
+    return SpAssetState(
+      collateralAsset: (json['asset'] as String?) ?? '',
+      sumVal: BigInt.parse((json['sumVal'] as String?) ?? '0'),
+      epochToScaleToSum: etsMap,
+    );
+  }
+}
+
 // https://github.com/IndigoProtocol/indigo-smart-contracts/blob/main/src/Indigo/Contracts/StabilityPool/Common.hs#L169C1-L191C4
 class StabilityPool {
   final String asset;
 
-  double get totalAmount =>
-      snapshotD / conversionValue; // ToDo: Remove to use snapshotD
+  double get totalAmount => snapshotD / conversionValue;
 
   final BigInt snapshotD;
   final BigInt snapshotP;
-  final BigInt snapshotS;
+  final BigInt? snapshotS;
   final int snapshotEpoch;
   final int snapshotScale;
 
-  Map<String, BigInt> epochToScaleToSum;
+  // V3: per-collateral reward streams; empty for pre-V3 records
+  final List<SpAssetState> assetStates;
 
-  StabilityPool(
-      {required this.asset,
-      required this.snapshotD,
-      required this.snapshotP,
-      required this.snapshotS,
-      required this.snapshotEpoch,
-      required this.snapshotScale,
-      required this.epochToScaleToSum});
+  // V2 compat: single global epoch-to-scale-to-sum (null in V3)
+  final Map<String, BigInt> epochToScaleToSum;
+
+  StabilityPool({
+    required this.asset,
+    required this.snapshotD,
+    required this.snapshotP,
+    this.snapshotS,
+    required this.snapshotEpoch,
+    required this.snapshotScale,
+    required this.epochToScaleToSum,
+    this.assetStates = const [],
+  });
 
   factory StabilityPool.fromJson(Map<String, dynamic> json) {
-    final Map<String, dynamic> rawEpochToScaleToSum =
-        jsonDecode(json['epoch_to_scale_to_sum'] as String)
-            as Map<String, dynamic>;
-    final Map<String, BigInt> parsedEpochToScaleToSum = {};
+    Map<String, BigInt> parsedEts = {};
+    final rawEts = json['epoch_to_scale_to_sum'];
+    if (rawEts is String) {
+      final decoded = jsonDecode(rawEts) as Map<String, dynamic>;
+      decoded.forEach((key, value) {
+        parsedEts[key] = BigInt.parse(value as String);
+      });
+    }
 
-    rawEpochToScaleToSum.forEach((key, value) {
-      parsedEpochToScaleToSum[key] = BigInt.parse(value as String);
-    });
+    List<SpAssetState> assetStates = [];
+    final rawAs = json['asset_states'];
+    if (rawAs is String) {
+      final decoded = jsonDecode(rawAs) as List<dynamic>;
+      assetStates = decoded
+          .map((e) => SpAssetState.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
 
     return StabilityPool(
       asset: json['asset'] as String,
       snapshotD: BigInt.parse(json['snapshotD'] as String),
       snapshotP: BigInt.parse(json['snapshotP'] as String),
-      snapshotS: BigInt.parse(json['snapshotS'] as String),
+      snapshotS: json['snapshotS'] != null
+          ? BigInt.parse(json['snapshotS'] as String)
+          : null,
       snapshotEpoch: json['snapshotEpoch'] as int,
       snapshotScale: json['snapshotScale'] as int,
-      epochToScaleToSum: parsedEpochToScaleToSum,
+      epochToScaleToSum: parsedEts,
+      assetStates: assetStates,
     );
   }
 
   double getAccountBalance(StabilityPoolAccount account) {
     if (snapshotEpoch != account.snapshotEpoch) return 0;
-
     if (snapshotScale - account.snapshotScale > 1) return 0;
-
     if (snapshotScale > account.snapshotScale) {
       return (account.snapshotD * snapshotP) ~/
           (account.snapshotP * BigInt.from(10).pow(9)) /
           conversionValue;
     }
-
     return (account.snapshotD * snapshotP) ~/
         account.snapshotP /
         conversionValue;
   }
 
+  // Returns ADA unclaimed rewards (V2 path). Returns 0 when data is unavailable (V3).
   double getAccountUnclaimedRewards(StabilityPoolAccount account) {
-    final s1 =
-        epochToScaleToSum['${account.snapshotEpoch},${account.snapshotScale}'];
+    final accountS = account.snapshotS;
+    if (accountS == null) return 0;
 
-    if (s1 == null) throw Exception('Could not find s1');
+    final key = '${account.snapshotEpoch},${account.snapshotScale}';
+    final s1 = epochToScaleToSum[key];
+    if (s1 == null) return 0;
+
     final s2 = epochToScaleToSum[
             '${account.snapshotEpoch},${account.snapshotScale + 1}'] ??
         s1;
-    final a1 = s1 - account.snapshotS;
+    final a1 = s1 - accountS;
     final a2 = BigInt.from((s2 - s1) / conversionValue);
 
     return BigInt.from(((a1 + a2) * account.snapshotD / account.snapshotP)) /

--- a/lib/models/stability_pool_account.dart
+++ b/lib/models/stability_pool_account.dart
@@ -1,4 +1,3 @@
-// Documentation about each property
 // https://github.com/IndigoProtocol/indigo-smart-contracts/blob/main/src/Indigo/Contracts/StabilityPool/Common.hs#L169C1-L191C4
 
 BigInt conversionValue = BigInt.from(10).pow(24);
@@ -6,23 +5,24 @@ BigInt conversionValue = BigInt.from(10).pow(24);
 class StabilityPoolAccount {
   final String asset;
   final String owner;
-  double get totalAmount =>
-      snapshotD / conversionValue; // ToDo: Remove to use snapshotD
+
+  double get totalAmount => snapshotD / conversionValue;
 
   final BigInt snapshotD;
   final BigInt snapshotP;
-  final BigInt snapshotS;
+  final BigInt? snapshotS; // null in V3 (moved to per-collateral asset_states)
   final int snapshotEpoch;
   final int snapshotScale;
 
-  StabilityPoolAccount(
-      {required this.asset,
-      required this.owner,
-      required this.snapshotD,
-      required this.snapshotP,
-      required this.snapshotS,
-      required this.snapshotEpoch,
-      required this.snapshotScale});
+  StabilityPoolAccount({
+    required this.asset,
+    required this.owner,
+    required this.snapshotD,
+    required this.snapshotP,
+    this.snapshotS,
+    required this.snapshotEpoch,
+    required this.snapshotScale,
+  });
 
   factory StabilityPoolAccount.fromJson(Map<String, dynamic> json) {
     return StabilityPoolAccount(
@@ -30,7 +30,9 @@ class StabilityPoolAccount {
       owner: json['owner'] as String,
       snapshotD: BigInt.parse(json['snapshotD'] as String),
       snapshotP: BigInt.parse(json['snapshotP'] as String),
-      snapshotS: BigInt.parse(json['snapshotS'] as String),
+      snapshotS: json['snapshotS'] != null
+          ? BigInt.parse(json['snapshotS'] as String)
+          : null,
       snapshotEpoch: json['snapshotEpoch'] as int,
       snapshotScale: json['snapshotScale'] as int,
     );

--- a/lib/repositories/apr_repository.dart
+++ b/lib/repositories/apr_repository.dart
@@ -1,0 +1,21 @@
+import 'package:indigo_insights/api/indigo_api/services/apr_service.dart';
+import 'package:indigo_insights/utils/cached_result.dart';
+
+class AprRepository {
+  static const _ttl = Duration(minutes: 5);
+
+  final AprService _service;
+  CachedResult<Map<String, double>>? _cache;
+
+  AprRepository(this._service);
+
+  Future<Map<String, double>> getAprs() async {
+    if (_cache != null && _cache!.isValid(_ttl)) return _cache!.value;
+    final entries = await _service.fetchAprs();
+    final map = {for (final e in entries) e.key: e.value};
+    _cache = CachedResult(map);
+    return map;
+  }
+
+  void invalidateCache() => _cache = null;
+}

--- a/lib/repositories/indigo_asset_repository.dart
+++ b/lib/repositories/indigo_asset_repository.dart
@@ -12,7 +12,7 @@ class IndigoAssetRepository {
 
   DateTime? get lastFetchedAt => _cache?.fetchedAt;
 
-  static const _preferredOrder = ['iUSD', 'iBTC', 'iETH', 'iSOL'];
+  static const _preferredOrder = ['iUSD', 'iBTC', 'iETH', 'iSOL', 'iJPY', 'iEUR'];
 
   Future<List<IndigoAsset>> getAssets() async {
     if (_cache != null && _cache!.isValid(_ttl)) return _cache!.value;

--- a/lib/repositories/indigo_asset_repository.dart
+++ b/lib/repositories/indigo_asset_repository.dart
@@ -20,8 +20,8 @@ class IndigoAssetRepository {
     result.sort((a, b) {
       final ai = _preferredOrder.indexOf(a.asset);
       final bi = _preferredOrder.indexOf(b.asset);
-      // Known assets in preferred order, then unknown assets by createdAt
-      if (ai == -1 && bi == -1) return a.createdAt.compareTo(b.createdAt);
+      // Known assets in preferred order, then unknown assets alphabetically
+      if (ai == -1 && bi == -1) return a.asset.compareTo(b.asset);
       if (ai == -1) return 1;
       if (bi == -1) return -1;
       return ai.compareTo(bi);

--- a/lib/repositories/solvency_repository.dart
+++ b/lib/repositories/solvency_repository.dart
@@ -44,12 +44,10 @@ class SolvencyRepository {
     double calculatePriceChangeToLiquidate(Cdp cdp) {
       final collateralInAsset = cdp.collateralAmount / assetPrice;
       final collateralRatio = collateralInAsset / cdp.mintedAmount;
-      final lr = indigoAsset.liquidationRatio / 100;
-      if (lr > collateralRatio) {
-        throw Exception(
-          'Liquidation ratio ($lr) is greater than collateral ratio ($collateralRatio)!',
-        );
-      }
+      final lrPct = indigoAsset.liquidationRatio;
+      if (lrPct == null) return 0; // V3: ratio lives on collateral pair
+      final lr = lrPct / 100;
+      if (lr > collateralRatio) return 0;
       return 1.00 - (lr / collateralRatio);
     }
 

--- a/lib/repositories/solvency_repository.dart
+++ b/lib/repositories/solvency_repository.dart
@@ -24,7 +24,6 @@ class SolvencyRepository {
     final cached = _cache[indigoAsset.asset];
     if (cached != null && cached.isValid(_ttl)) return cached.value;
 
-    // All three fire in parallel — upstream TTL caches absorb duplicate calls
     final results = await Future.wait([
       _prices.getPrices(),
       _pools.getPools(),
@@ -35,51 +34,57 @@ class SolvencyRepository {
     final pools = results[1] as List<StabilityPool>;
     final cdpsAll = results[2] as List<Cdp>;
 
-    final assetPrice = assetPrices
-        .firstWhere((ap) => ap.asset == indigoAsset.asset)
-        .price;
-    final stabilityPool = pools.firstWhere((sp) => sp.asset == indigoAsset.asset);
+    final stabilityPool =
+        pools.firstWhereOrNull((sp) => sp.asset == indigoAsset.asset);
+    if (stabilityPool == null) {
+      _cache[indigoAsset.asset] = CachedResult([]);
+      return [];
+    }
     final spTotal = stabilityPool.totalAmount;
 
-    double calculatePriceChangeToLiquidate(Cdp cdp) {
-      final collateralInAsset = cdp.collateralAmount / assetPrice;
-      final collateralRatio = collateralInAsset / cdp.mintedAmount;
-      final lrPct = indigoAsset.liquidationRatio;
-      if (lrPct == null) return 0; // V3: ratio lives on collateral pair
+    // Pre-build O(1) maps so the inner loop over CDPs stays fast.
+    final priceByCollateral = <String, double>{
+      for (final p in assetPrices.where((p) => p.asset == indigoAsset.asset))
+        p.collateralAsset: p.price,
+    };
+    final lrByCollateral = <String, double>{
+      for (final p in indigoAsset.collateralAssets)
+        p.collateralAsset: p.liquidationRatioPercent,
+    };
+
+    double percentToLiquidate(Cdp cdp) {
+      if (cdp.mintedAmount <= 0) return 0;
+      final price = priceByCollateral[cdp.collateralAsset] ?? 1.0;
+      final lrPct = lrByCollateral[cdp.collateralAsset] ?? 110.0;
       final lr = lrPct / 100;
-      if (lr > collateralRatio) return 0;
-      return 1.00 - (lr / collateralRatio);
+      final cr = (cdp.collateralAmount / price) / cdp.mintedAmount;
+      if (lr >= cr) return 0; // already undercollateralised at current price
+      return 1.0 - (lr / cr);
     }
 
     final cdps = cdpsAll.where((cdp) => cdp.asset == indigoAsset.asset);
 
-    final percentToLiqAndCollateralData = cdps
-        .map(
-          (cdp) => (
-            minted: cdp.mintedAmount,
-            percentToLiquidate:
-                (calculatePriceChangeToLiquidate(cdp) * 100).round(),
-          ),
-        )
+    final grouped = cdps
+        .map((cdp) => (
+              minted: cdp.mintedAmount,
+              bucket: (percentToLiquidate(cdp) * 100).round(),
+            ))
         .groupFoldBy<int, double>(
-          (item) => item.percentToLiquidate,
+          (item) => item.bucket,
           (a, b) => (a ?? 0) + b.minted,
         )
         .entries
-        .map(
-          (entry) =>
-              (percentToLiq: entry.key.toDouble() / 100, minted: entry.value),
-        )
+        .map((e) => (pct: e.key.toDouble() / 100, minted: e.value))
         .toList()
-      ..sort((a, b) => a.percentToLiq.compareTo(b.percentToLiq));
+      ..sort((a, b) => a.pct.compareTo(b.pct));
 
     double spAmount = spTotal;
-    final amountPercentageData = percentToLiqAndCollateralData.map((item) {
+    final curve = grouped.map((item) {
       spAmount -= item.minted;
-      return AmountPercentageData(item.percentToLiq, spAmount);
+      return AmountPercentageData(item.pct, spAmount);
     }).toList();
 
-    final value = normalizeAmountPercentageData(amountPercentageData, 60, spTotal);
+    final value = normalizeAmountPercentageData(curve, 60, spTotal);
     _cache[indigoAsset.asset] = CachedResult(value);
     return value;
   }

--- a/lib/repositories/strategy_repository.dart
+++ b/lib/repositories/strategy_repository.dart
@@ -4,16 +4,17 @@ import 'package:indigo_insights/models/asset_price.dart';
 import 'package:indigo_insights/models/indigo_asset.dart';
 import 'package:indigo_insights/models/liquidity_pool_yield.dart';
 import 'package:indigo_insights/models/stability_pool.dart';
+import 'package:indigo_insights/repositories/apr_repository.dart';
 import 'package:indigo_insights/repositories/asset_price_repository.dart';
 import 'package:indigo_insights/repositories/cdp_repository.dart';
 import 'package:indigo_insights/repositories/dex_yield_repository.dart';
 import 'package:indigo_insights/repositories/indigo_asset_repository.dart';
-import 'package:indigo_insights/repositories/indy_price_repository.dart';
 import 'package:indigo_insights/repositories/stability_pool_repository.dart';
 import 'package:indigo_insights/utils/cached_result.dart';
 
 typedef LeverageData = ({
   String asset,
+  String collateralAsset,
   double interestRate,
   double? rmr,
   double? mcr,
@@ -24,12 +25,11 @@ typedef LeverageData = ({
 
 typedef StabilityPoolStrategyData = ({
   String title,
+  String collateralAsset,
   double strategyYield,
   double poolYield,
   double interestRate,
-  double? rmr,
-  double? mcr,
-  double? liquidationRatio,
+  double assetPrice,
   double debtMintingFee,
 });
 
@@ -39,22 +39,8 @@ typedef StablePoolStrategyData = ({
   double tradingFeesApr,
   double farmingApr,
   double interestRate,
-  double? rmr,
-  double? mcr,
-  double? liquidationRatio,
   double debtMintingFee,
 });
-
-double _incentivesPerYear(String asset) =>
-    switch (asset) {
-      'iUSD' => 8000,
-      'iBTC' => 2000,
-      'iETH' => 500,
-      'iSOL' => 120,
-      _ => 0,
-    } *
-    365 /
-    5;
 
 Map<String, AssetInterestRate> _buildInterestRateMap(
   List<AssetInterestRate> rates,
@@ -72,10 +58,6 @@ Map<String, AssetInterestRate> _buildInterestRateMap(
   return map;
 }
 
-// Returns the global price for an asset (collateral_asset == "").
-double? _globalPrice(List<AssetPrice> prices, String asset) =>
-    prices.firstWhereOrNull((p) => p.asset == asset && p.collateralAsset.isEmpty)?.price ??
-    prices.firstWhereOrNull((p) => p.asset == asset)?.price;
 
 class StrategyRepository {
   static const _ttl = Duration(minutes: 5);
@@ -84,8 +66,8 @@ class StrategyRepository {
   final AssetPriceRepository _prices;
   final CdpRepository _cdps;
   final StabilityPoolRepository _pools;
-  final IndyPriceRepository _indyPrice;
   final DexYieldRepository _dexYields;
+  final AprRepository _aprs;
 
   CachedResult<List<LeverageData>>? _leverageCache;
   CachedResult<List<StabilityPoolStrategyData>>? _spFarmingCache;
@@ -96,8 +78,8 @@ class StrategyRepository {
     this._prices,
     this._cdps,
     this._pools,
-    this._indyPrice,
     this._dexYields,
+    this._aprs,
   );
 
   /// Shared data for all 3 leverage strategies (above RMR, above MCR, double above MCR).
@@ -119,22 +101,26 @@ class StrategyRepository {
     final irMap = _buildInterestRateMap(interestRates);
     final List<LeverageData> leverages = [];
 
-    for (final iAsset in indigoAssets) {
-      final interestRate = irMap[iAsset.asset]?.interestRate ?? 0.0;
-      final price = _globalPrice(assetPrices, iAsset.asset) ?? 0.0;
-
+    // One entry per (iAsset, collateralAsset) price combination.
+    for (final price in assetPrices) {
+      final iAsset = indigoAssets.firstWhereOrNull((ia) => ia.asset == price.asset);
+      if (iAsset == null) continue;
+      final interestRate = irMap[price.asset]?.interestRate ?? 0.0;
       leverages.add((
-        asset: iAsset.asset,
+        asset: price.asset,
+        collateralAsset: price.collateralAsset,
         interestRate: interestRate * 100,
         rmr: iAsset.rmr,
         mcr: iAsset.maintenanceRatio,
         liquidationRatio: iAsset.liquidationRatio,
-        assetPrice: price,
+        assetPrice: price.price,
         debtMintingFee: iAsset.debtMintingFee,
       ));
     }
 
-    final result = leverages.sortedBy((e) => e.asset).toList();
+    final result = leverages
+        .sortedBy((e) => e.asset)
+        .toList();
     _leverageCache = CachedResult(result);
     return result;
   }
@@ -147,41 +133,44 @@ class StrategyRepository {
     final results = await Future.wait([
       _prices.getPrices(),
       _pools.getPools(),
-      _indyPrice.getPrice(),
       _assets.getAssets(),
       _cdps.getAssetInterestRates(),
+      _aprs.getAprs(),
     ]);
 
     final assetPrices = results[0] as List<AssetPrice>;
     final stabilityPools = results[1] as List<StabilityPool>;
-    final indyPrice = results[2] as double;
-    final indigoAssets = results[3] as List<IndigoAsset>;
-    final interestRates = results[4] as List<AssetInterestRate>;
+    final indigoAssets = results[2] as List<IndigoAsset>;
+    final interestRates = results[3] as List<AssetInterestRate>;
+    final aprMap = results[4] as Map<String, double>;
 
     final irMap = _buildInterestRateMap(interestRates);
     final List<StabilityPoolStrategyData> strategies = [];
 
     for (final sp in stabilityPools) {
       final asset = sp.asset;
-      final spTotal = sp.totalAmount;
-      final iAsset = indigoAssets.firstWhere((ia) => ia.asset == asset);
-      final aprice = _globalPrice(assetPrices, asset) ?? 1.0;
-
-      final stabilityPoolApr = spTotal > 0
-          ? (_incentivesPerYear(asset) * indyPrice) / (spTotal * aprice)
-          : 0.0;
+      final iAsset = indigoAssets.firstWhereOrNull((ia) => ia.asset == asset);
+      if (iAsset == null) continue;
       final interestRate = irMap[asset]?.interestRate ?? 0.0;
 
-      strategies.add((
-        title: asset,
-        strategyYield: (stabilityPoolApr - interestRate) * 100,
-        poolYield: stabilityPoolApr * 100,
-        interestRate: interestRate * 100,
-        rmr: iAsset.rmr,
-        mcr: iAsset.maintenanceRatio,
-        liquidationRatio: iAsset.liquidationRatio,
-        debtMintingFee: iAsset.debtMintingFee,
-      ));
+      // SP APR from official endpoint (already in %, same for all collaterals of this asset).
+      final indyApr = aprMap['sp_${asset}_indy'] ?? 0.0;
+      final adaApr = aprMap['sp_${asset}_ada'] ?? 0.0;
+      final poolYield = indyApr + adaApr;
+
+      // One card per collateral price available for this asset.
+      final pricesForAsset = assetPrices.where((p) => p.asset == asset).toList();
+      for (final price in pricesForAsset) {
+        strategies.add((
+          title: asset,
+          collateralAsset: price.collateralAsset,
+          strategyYield: poolYield - (interestRate * 100),
+          poolYield: poolYield,
+          interestRate: interestRate * 100,
+          assetPrice: price.price,
+          debtMintingFee: iAsset.debtMintingFee,
+        ));
+      }
     }
 
     final result = strategies.sortedBy((a) => a.strategyYield).reversed.toList();
@@ -223,9 +212,6 @@ class StrategyRepository {
         tradingFeesApr: e.tradingFeesApr,
         farmingApr: e.farmingApr,
         interestRate: interestRate * 100,
-        rmr: iAsset.rmr,
-        mcr: iAsset.maintenanceRatio,
-        liquidationRatio: iAsset.liquidationRatio,
         debtMintingFee: iAsset.debtMintingFee,
       ));
     }

--- a/lib/repositories/strategy_repository.dart
+++ b/lib/repositories/strategy_repository.dart
@@ -15,9 +15,9 @@ import 'package:indigo_insights/utils/cached_result.dart';
 typedef LeverageData = ({
   String asset,
   double interestRate,
-  double rmr,
-  double mcr,
-  double liquidationRatio,
+  double? rmr,
+  double? mcr,
+  double? liquidationRatio,
   double assetPrice,
   double debtMintingFee,
 });
@@ -27,9 +27,9 @@ typedef StabilityPoolStrategyData = ({
   double strategyYield,
   double poolYield,
   double interestRate,
-  double rmr,
-  double mcr,
-  double liquidationRatio,
+  double? rmr,
+  double? mcr,
+  double? liquidationRatio,
   double debtMintingFee,
 });
 
@@ -39,9 +39,9 @@ typedef StablePoolStrategyData = ({
   double tradingFeesApr,
   double farmingApr,
   double interestRate,
-  double rmr,
-  double mcr,
-  double liquidationRatio,
+  double? rmr,
+  double? mcr,
+  double? liquidationRatio,
   double debtMintingFee,
 });
 
@@ -61,12 +61,21 @@ Map<String, AssetInterestRate> _buildInterestRateMap(
 ) {
   final Map<String, AssetInterestRate> map = {};
   for (final ir in rates) {
-    if (!map.containsKey(ir.asset) || map[ir.asset]!.slot < ir.slot) {
+    // Prefer the ADA-collateral (global) rate when multiple collaterals exist
+    if (!map.containsKey(ir.asset) ||
+        (ir.collateralAsset.isEmpty && map[ir.asset]!.collateralAsset.isNotEmpty) ||
+        (ir.collateralAsset == map[ir.asset]!.collateralAsset &&
+            map[ir.asset]!.slot < ir.slot)) {
       map[ir.asset] = ir;
     }
   }
   return map;
 }
+
+// Returns the global price for an asset (collateral_asset == "").
+double? _globalPrice(List<AssetPrice> prices, String asset) =>
+    prices.firstWhereOrNull((p) => p.asset == asset && p.collateralAsset.isEmpty)?.price ??
+    prices.firstWhereOrNull((p) => p.asset == asset)?.price;
 
 class StrategyRepository {
   static const _ttl = Duration(minutes: 5);
@@ -92,7 +101,6 @@ class StrategyRepository {
   );
 
   /// Shared data for all 3 leverage strategies (above RMR, above MCR, double above MCR).
-  /// The UI pages differ only in their card rendering and which ratio they highlight.
   Future<List<LeverageData>> getLeverageData() async {
     if (_leverageCache != null && _leverageCache!.isValid(_ttl)) {
       return _leverageCache!.value;
@@ -113,9 +121,7 @@ class StrategyRepository {
 
     for (final iAsset in indigoAssets) {
       final interestRate = irMap[iAsset.asset]?.interestRate ?? 0.0;
-      final currentAssetPrice = assetPrices
-          .firstWhere((ap) => ap.asset == iAsset.asset)
-          .price;
+      final price = _globalPrice(assetPrices, iAsset.asset) ?? 0.0;
 
       leverages.add((
         asset: iAsset.asset,
@@ -123,7 +129,7 @@ class StrategyRepository {
         rmr: iAsset.rmr,
         mcr: iAsset.maintenanceRatio,
         liquidationRatio: iAsset.liquidationRatio,
-        assetPrice: currentAssetPrice,
+        assetPrice: price,
         debtMintingFee: iAsset.debtMintingFee,
       ));
     }
@@ -159,10 +165,11 @@ class StrategyRepository {
       final asset = sp.asset;
       final spTotal = sp.totalAmount;
       final iAsset = indigoAssets.firstWhere((ia) => ia.asset == asset);
-      final aprice = assetPrices.firstWhere((ap) => ap.asset == asset).price;
+      final aprice = _globalPrice(assetPrices, asset) ?? 1.0;
 
-      final stabilityPoolApr =
-          (_incentivesPerYear(asset) * indyPrice) / (spTotal * aprice);
+      final stabilityPoolApr = spTotal > 0
+          ? (_incentivesPerYear(asset) * indyPrice) / (spTotal * aprice)
+          : 0.0;
       final interestRate = irMap[asset]?.interestRate ?? 0.0;
 
       strategies.add((

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -1,4 +1,5 @@
 import 'package:get_it/get_it.dart';
+import 'package:indigo_insights/api/indigo_api/services/apr_service.dart';
 import 'package:indigo_insights/api/indigo_api/services/asset_price_service.dart';
 import 'package:indigo_insights/api/indigo_api/services/asset_status_service.dart';
 import 'package:indigo_insights/api/indigo_api/services/cdp_service.dart';
@@ -10,6 +11,7 @@ import 'package:indigo_insights/api/indigo_api/services/redemption_service.dart'
 import 'package:indigo_insights/api/indigo_api/services/stability_pool_account_service.dart';
 import 'package:indigo_insights/api/indigo_api/services/stability_pool_service.dart';
 import 'package:indigo_insights/api/indigo_api/services/stake_history_service.dart';
+import 'package:indigo_insights/repositories/apr_repository.dart';
 import 'package:indigo_insights/repositories/asset_price_repository.dart';
 import 'package:indigo_insights/repositories/asset_status_repository.dart';
 import 'package:indigo_insights/repositories/cdp_repository.dart';
@@ -29,6 +31,7 @@ final GetIt sl = GetIt.instance;
 
 void setupServiceLocator() {
   // Services
+  sl.registerLazySingleton(() => AprService());
   sl.registerLazySingleton(() => AssetPriceService());
   sl.registerLazySingleton(() => AssetStatusService());
   sl.registerLazySingleton(() => CdpService());
@@ -42,6 +45,7 @@ void setupServiceLocator() {
   sl.registerLazySingleton(() => StakeHistoryService());
 
   // Base repositories — lazy singletons (created on first access, live for app lifetime)
+  sl.registerLazySingleton(() => AprRepository(sl()));
   sl.registerLazySingleton(() => AssetPriceRepository(sl()));
   sl.registerLazySingleton(() => AssetStatusRepository(sl()));
   sl.registerLazySingleton(() => CdpRepository(sl()));

--- a/lib/utils/formatters.dart
+++ b/lib/utils/formatters.dart
@@ -67,3 +67,24 @@ List<T> sortedByAsset<T>(List<T> items, String Function(T) getName) {
       .compareTo(assetSortIndex(getName(b))));
   return copy;
 }
+
+/// Decode a Cardano collateral asset identifier to a human-readable label.
+/// Empty string → "ADA"; policy.hexTokenName → decoded token name (e.g. "NIGHT").
+String collateralLabel(String collateralAsset) {
+  if (collateralAsset.isEmpty) return 'ADA';
+  final parts = collateralAsset.split('.');
+  if (parts.length == 2) {
+    try {
+      final hex = parts[1];
+      final bytes = <int>[
+        for (var i = 0; i + 1 < hex.length; i += 2)
+          int.parse(hex.substring(i, i + 2), radix: 16),
+      ];
+      final name = String.fromCharCodes(bytes);
+      if (name.isNotEmpty) return name;
+    } catch (_) {}
+  }
+  return collateralAsset.length > 8
+      ? '${collateralAsset.substring(0, 8)}…'
+      : collateralAsset;
+}

--- a/lib/views/insights/cdp_explorer/cdp_explorer_insights.dart
+++ b/lib/views/insights/cdp_explorer/cdp_explorer_insights.dart
@@ -31,12 +31,20 @@ typedef _CdpExplorerData = ({
 enum _CdpTier { whale, shark, dolphin, fish, shrimp }
 
 extension _CdpTierX on _CdpTier {
-  String get label => switch (this) {
-        _CdpTier.whale => 'Whale\n>1M ADA',
-        _CdpTier.shark => 'Shark\n100k–1M',
-        _CdpTier.dolphin => 'Dolphin\n10k–100k',
-        _CdpTier.fish => 'Fish\n100–10k',
-        _CdpTier.shrimp => 'Shrimp\n<100 ADA',
+  String get tierName => switch (this) {
+        _CdpTier.whale => 'Whale',
+        _CdpTier.shark => 'Shark',
+        _CdpTier.dolphin => 'Dolphin',
+        _CdpTier.fish => 'Fish',
+        _CdpTier.shrimp => 'Shrimp',
+      };
+
+  String get range => switch (this) {
+        _CdpTier.whale => '>1M',
+        _CdpTier.shark => '100k–1M',
+        _CdpTier.dolphin => '10k–100k',
+        _CdpTier.fish => '100–10k',
+        _CdpTier.shrimp => '<100',
       };
 
   bool matches(Cdp cdp) => switch (this) {
@@ -78,7 +86,8 @@ class CdpExplorerInsights extends StatelessWidget {
                 assets: results[2] as List<IndigoAsset>,
               );
             },
-            builder: (data) => _CdpExplorerContent(data: data, initialTab: initialTab),
+            builder: (data) =>
+                _CdpExplorerContent(data: data, initialTab: initialTab),
             errorBuilder: (error, retry) =>
                 Center(child: Text(error.toString())),
           ),
@@ -109,20 +118,18 @@ class _CdpExplorerContentState extends State<_CdpExplorerContent>
     super.initState();
     _sortedAssets = [...widget.data.assets];
     _sortedAssets.sort((a, b) {
+      final aPrice =
+          widget.data.prices.firstWhereOrNull((p) => p.asset == a.asset)?.price ?? 0.0;
+      final bPrice =
+          widget.data.prices.firstWhereOrNull((p) => p.asset == b.asset)?.price ?? 0.0;
       final aTotal = widget.data.cdps
               .where((c) => c.asset == a.asset)
               .fold(0.0, (s, c) => s + c.mintedAmount) *
-          (widget.data.prices
-                  .firstWhereOrNull((p) => p.asset == a.asset)
-                  ?.price ??
-              0.0);
+          aPrice;
       final bTotal = widget.data.cdps
               .where((c) => c.asset == b.asset)
               .fold(0.0, (s, c) => s + c.mintedAmount) *
-          (widget.data.prices
-                  .firstWhereOrNull((p) => p.asset == b.asset)
-                  ?.price ??
-              0.0);
+          bPrice;
       return bTotal.compareTo(aTotal);
     });
     int initialIndex = 0;
@@ -161,17 +168,17 @@ class _CdpExplorerContentState extends State<_CdpExplorerContent>
               child: TabBarView(
                 controller: _tabController,
                 children: _sortedAssets.map((asset) {
-                  final price = widget.data.prices
-                          .firstWhereOrNull((p) => p.asset == asset.asset)
-                          ?.price ??
-                      1.0;
+                  final priceByCollateral = <String, double>{
+                    for (final p in widget.data.prices.where((p) => p.asset == asset.asset))
+                      p.collateralAsset: p.price,
+                  };
                   final assetCdps = widget.data.cdps
                       .where((c) => c.asset == asset.asset)
                       .toList();
                   return _AssetCdpTab(
                     asset: asset,
                     cdps: assetCdps,
-                    assetPriceAda: price,
+                    priceByCollateral: priceByCollateral,
                   );
                 }).toList(),
               ),
@@ -188,12 +195,12 @@ class _CdpExplorerContentState extends State<_CdpExplorerContent>
 class _AssetCdpTab extends StatefulWidget {
   final IndigoAsset asset;
   final List<Cdp> cdps;
-  final double assetPriceAda;
+  final Map<String, double> priceByCollateral;
 
   const _AssetCdpTab({
     required this.asset,
     required this.cdps,
-    required this.assetPriceAda,
+    required this.priceByCollateral,
   });
 
   @override
@@ -202,11 +209,12 @@ class _AssetCdpTab extends StatefulWidget {
 
 class _AssetCdpTabState extends State<_AssetCdpTab> {
   _CdpTier _selectedTier = _CdpTier.dolphin;
+  String? _collateralFilter; // null = all
 
   double _collateralRatio(Cdp cdp) {
     if (cdp.mintedAmount <= 0) return double.infinity;
-    final collateralInAsset = cdp.collateralAmount / widget.assetPriceAda;
-    return (collateralInAsset / cdp.mintedAmount) * 100;
+    final price = widget.priceByCollateral[cdp.collateralAsset] ?? 1.0;
+    return ((cdp.collateralAmount / price) / cdp.mintedAmount) * 100;
   }
 
   @override
@@ -217,11 +225,13 @@ class _AssetCdpTabState extends State<_AssetCdpTab> {
       return const Center(child: Text('No CDPs for this asset.'));
     }
 
-    final sizeTiersCard = _CdpSizeTiersCard(
+    final filtersBar = _FiltersBar(
       asset: widget.asset,
       cdps: widget.cdps,
       selectedTier: _selectedTier,
-      onTierSelected: (t) => setState(() => _selectedTier = t),
+      onTierChanged: (t) => setState(() => _selectedTier = t),
+      collateralFilter: _collateralFilter,
+      onCollateralChanged: (c) => setState(() => _collateralFilter = c),
     );
 
     final crChart = _CrDistributionCard(
@@ -233,9 +243,10 @@ class _AssetCdpTabState extends State<_AssetCdpTab> {
     final table = _CdpsTable(
       asset: widget.asset,
       cdps: widget.cdps,
-      assetPriceAda: widget.assetPriceAda,
+      priceByCollateral: widget.priceByCollateral,
       crOf: _collateralRatio,
       tierFilter: _selectedTier,
+      collateralFilter: _collateralFilter,
     );
 
     if (isDesktop) {
@@ -246,7 +257,7 @@ class _AssetCdpTabState extends State<_AssetCdpTab> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                sizeTiersCard,
+                filtersBar,
                 const SizedBox(height: 16),
                 Expanded(child: table),
               ],
@@ -263,7 +274,7 @@ class _AssetCdpTabState extends State<_AssetCdpTab> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          sizeTiersCard,
+          filtersBar,
           const SizedBox(height: 16),
           SizedBox(height: 400, child: table),
           const SizedBox(height: 16),
@@ -340,10 +351,7 @@ class _CrDistributionCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'CR Distribution (${asset.asset})',
-            style: styles.cardTitle,
-          ),
+          Text('CR Distribution (${asset.asset})', style: styles.cardTitle),
           const SizedBox(height: 4),
           Text(
             'Minted ${asset.asset} by Collateral Ratio bucket',
@@ -431,38 +439,70 @@ class _CrDistributionCard extends StatelessWidget {
   }
 }
 
-// ─── CDP Size Tiers (tappable chips) ──────────────────────────────────────────
+// ─── Filters Bar (dropdowns) ───────────────────────────────────────────────────
 
-class _CdpSizeTiersCard extends StatelessWidget {
+class _FiltersBar extends StatelessWidget {
   final IndigoAsset asset;
   final List<Cdp> cdps;
   final _CdpTier selectedTier;
-  final ValueChanged<_CdpTier> onTierSelected;
+  final ValueChanged<_CdpTier> onTierChanged;
+  final String? collateralFilter;
+  final ValueChanged<String?> onCollateralChanged;
 
-  const _CdpSizeTiersCard({
+  const _FiltersBar({
     required this.asset,
     required this.cdps,
     required this.selectedTier,
-    required this.onTierSelected,
+    required this.onTierChanged,
+    required this.collateralFilter,
+    required this.onCollateralChanged,
   });
+
+  String _collateralSummary(List<Cdp> list) {
+    final byType = <String, double>{};
+    for (final c in list) {
+      byType[c.collateralAsset] = (byType[c.collateralAsset] ?? 0) + c.collateralAmount;
+    }
+    if (byType.isEmpty) return '—';
+    return byType.entries.map((e) {
+      final abbr = getAbbreviation(e.value);
+      return '${numberAbbreviatedFormatter(e.value, abbr)} ${collateralLabel(e.key)}';
+    }).join(' + ');
+  }
 
   @override
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
 
-    final tiers = [
-      _CdpTier.whale,
-      _CdpTier.shark,
-      _CdpTier.dolphin,
-      _CdpTier.fish,
-      _CdpTier.shrimp,
-    ];
+    // Distinct collateral types present in CDPs for this asset.
+    final collateralTypes = cdps
+        .map((c) => c.collateralAsset)
+        .toSet()
+        .toList()
+      ..sort((a, b) => collateralLabel(a).compareTo(collateralLabel(b)));
 
-    double totalCollateral(List<Cdp> list) =>
-        list.fold(0.0, (s, c) => s + c.collateralAmount);
-    double totalMinted(List<Cdp> list) =>
-        list.fold(0.0, (s, c) => s + c.mintedAmount);
+    // Build tier dropdown items with full stats.
+    final tierItems = _CdpTier.values.map((tier) {
+      final list = cdps.where(tier.matches).toList();
+      final mint = list.fold(0.0, (s, c) => s + c.mintedAmount);
+      final mintAbbr = getAbbreviation(mint);
+      return _DropdownItem<_CdpTier>(
+        value: tier,
+        label: '${tier.tierName}  ·  ${tier.range}',
+        subtitle:
+            '${list.length} positions  ·  ${_collateralSummary(list)}  ·  '
+            '${numberAbbreviatedFormatter(mint, mintAbbr)} ${asset.asset}',
+      );
+    }).toList();
+
+    // Build collateral dropdown items.
+    final collateralItems = [
+      const _DropdownItem<String?>(value: null, label: 'All'),
+      ...collateralTypes.map(
+        (c) => _DropdownItem<String?>(value: c, label: collateralLabel(c)),
+      ),
+    ];
 
     return IICard(
       padding: const EdgeInsets.all(16),
@@ -471,71 +511,32 @@ class _CdpSizeTiersCard extends StatelessWidget {
         children: [
           Text('CDP Size Distribution', style: styles.cardTitle),
           const SizedBox(height: 12),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: tiers.map((tier) {
-              final list = cdps.where(tier.matches).toList();
-              final col = totalCollateral(list);
-              final mint = totalMinted(list);
-              final collAbbr = getAbbreviation(col);
-              final mintAbbr = getAbbreviation(mint);
-              final isSelected = selectedTier == tier;
-
-              return Material(
-                color: Colors.transparent,
-                borderRadius: BorderRadius.circular(8),
-                clipBehavior: Clip.antiAlias,
-                child: InkWell(
-                  onTap: () => onTierSelected(tier),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 180),
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      gradient: isSelected ? accentSelectionGradient : null,
-                      color: isSelected ? null : colors.surfaceRaised,
-                      border: isSelected
-                          ? Border.all(color: colors.primaryBorder)
-                          : null,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          tier.label,
-                          style: styles.bodySm.copyWith(
-                            color: isSelected
-                                ? colors.primary
-                                : colors.textSecondary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          '${list.length} positions',
-                          style: styles.monoSm.copyWith(
-                            color: colors.textPrimary,
-                          ),
-                        ),
-                        Text(
-                          '${numberAbbreviatedFormatter(col, collAbbr)} ADA',
-                          style: styles.bodySm.copyWith(
-                            color: colors.textSecondary,
-                          ),
-                        ),
-                        Text(
-                          '${numberAbbreviatedFormatter(mint, mintAbbr)} ${asset.asset}',
-                          style: styles.bodySm.copyWith(
-                            color: colors.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ),
+          Row(
+            children: [
+              Expanded(
+                child: _StyledDropdown<_CdpTier>(
+                  prefixLabel: 'Size',
+                  value: selectedTier,
+                  items: tierItems,
+                  onChanged: (v) { if (v != null) onTierChanged(v); },
+                  colors: colors,
+                  styles: styles,
+                ),
+              ),
+              if (collateralTypes.length > 1) ...[
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _StyledDropdown<String?>(
+                    prefixLabel: 'Collateral',
+                    value: collateralFilter,
+                    items: collateralItems,
+                    onChanged: onCollateralChanged,
+                    colors: colors,
+                    styles: styles,
                   ),
                 ),
-              );
-            }).toList(),
+              ],
+            ],
           ),
         ],
       ),
@@ -543,21 +544,131 @@ class _CdpSizeTiersCard extends StatelessWidget {
   }
 }
 
-// ─── CDPs Table (tier-filtered) ───────────────────────────────────────────────
+// ─── Generic styled dropdown ───────────────────────────────────────────────────
+
+class _DropdownItem<T> {
+  final T value;
+  final String label;
+  final String? subtitle;
+
+  const _DropdownItem({required this.value, required this.label, this.subtitle});
+}
+
+class _StyledDropdown<T> extends StatelessWidget {
+  final String prefixLabel;
+  final T value;
+  final List<_DropdownItem<T>> items;
+  final ValueChanged<T?> onChanged;
+  final AppColorScheme colors;
+  final AppTextStyles styles;
+
+  const _StyledDropdown({
+    required this.prefixLabel,
+    required this.value,
+    required this.items,
+    required this.onChanged,
+    required this.colors,
+    required this.styles,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = items.firstWhereOrNull((i) => i.value == value) ?? items.first;
+
+    return PopupMenuButton<dynamic>(
+      position: PopupMenuPosition.under,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: colors.border),
+      ),
+      color: colors.surface,
+      elevation: 8,
+      // onTap per-item handles null values correctly (onSelected skips nulls).
+      itemBuilder: (context) => items.map((item) {
+        final isSelected = item.value == value;
+        return PopupMenuItem<dynamic>(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          onTap: () => onChanged(item.value),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      item.label,
+                      style: styles.bodySm.copyWith(
+                        color: isSelected ? colors.primary : colors.textPrimary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (item.subtitle != null) ...[
+                      const SizedBox(height: 3),
+                      Text(
+                        item.subtitle!,
+                        style: styles.bodySm.copyWith(
+                          color: colors.textMuted,
+                          fontSize: 10,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              if (isSelected)
+                Icon(Icons.check, size: 14, color: colors.primary),
+            ],
+          ),
+        );
+      }).toList(),
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: colors.surfaceRaised,
+          border: Border.all(color: colors.border),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          children: [
+            Text(
+              '$prefixLabel: ',
+              style: styles.bodySm.copyWith(color: colors.textMuted),
+            ),
+            Text(
+              selected.label,
+              style: styles.bodySm.copyWith(
+                color: colors.textPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const Spacer(),
+            Icon(Icons.expand_more, size: 16, color: colors.textMuted),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─── CDPs Table (tier + collateral filtered) ───────────────────────────────────
 
 class _CdpsTable extends StatefulWidget {
   final IndigoAsset asset;
   final List<Cdp> cdps;
-  final double assetPriceAda;
+  final Map<String, double> priceByCollateral;
   final double Function(Cdp) crOf;
   final _CdpTier tierFilter;
+  final String? collateralFilter;
 
   const _CdpsTable({
     required this.asset,
     required this.cdps,
-    required this.assetPriceAda,
+    required this.priceByCollateral,
     required this.crOf,
     required this.tierFilter,
+    required this.collateralFilter,
   });
 
   @override
@@ -580,20 +691,30 @@ class _CdpsTableState extends State<_CdpsTable> {
   @override
   void didUpdateWidget(_CdpsTable oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.tierFilter != widget.tierFilter) _page = 0;
+    if (oldWidget.tierFilter != widget.tierFilter ||
+        oldWidget.collateralFilter != widget.collateralFilter) {
+      _page = 0;
+    }
   }
 
   double _liqPrice(Cdp cdp) {
-    if (cdp.mintedAmount <= 0 || widget.asset.liquidationRatio == null) return 0;
-    return cdp.collateralAmount / (cdp.mintedAmount * (widget.asset.liquidationRatio! / 100));
+    if (cdp.mintedAmount <= 0) return 0;
+    final lr = widget.asset.getLiquidationRatio(cdp.collateralAsset);
+    return cdp.collateralAmount / (cdp.mintedAmount * (lr / 100));
   }
 
-  Color _crColor(double cr, AppColorScheme colors) {
-    final liq = widget.asset.liquidationRatio;
-    final mcr = widget.asset.maintenanceRatio;
+  double _dropToLiq(Cdp cdp) {
+    final currentPrice = widget.priceByCollateral[cdp.collateralAsset] ?? 0.0;
+    if (currentPrice <= 0) return 0.0;
+    return (1 - _liqPrice(cdp) / currentPrice) * 100;
+  }
+
+  Color _crColor(Cdp cdp, double cr, AppColorScheme colors) {
+    final liq = widget.asset.getLiquidationRatio(cdp.collateralAsset);
+    final mcr = widget.asset.getMaintenanceRatio(cdp.collateralAsset);
     final rmr = widget.asset.rmr;
-    if (liq != null && cr < liq) return colors.error;
-    if (mcr != null && cr < mcr) return const Color(0xFFE64A19);
+    if (cr < liq) return colors.error;
+    if (cr < mcr) return const Color(0xFFE64A19);
     if (rmr != null && cr < rmr) return colors.warning;
     if (cr < 200) return const Color(0xFF0288D1);
     return colors.success;
@@ -607,14 +728,16 @@ class _CdpsTableState extends State<_CdpsTable> {
     final filtered = widget.cdps
         .where((c) => widget.crOf(c).isFinite)
         .where(widget.tierFilter.matches)
+        .where((c) =>
+            widget.collateralFilter == null ||
+            c.collateralAsset == widget.collateralFilter)
         .sortedByCompare<double>(
           (c) => widget.crOf(c),
           (a, b) => a.compareTo(b),
         );
 
     final totalPages = (filtered.length / _pageSize).ceil();
-    final pageItems =
-        filtered.skip(_page * _pageSize).take(_pageSize).toList();
+    final pageItems = filtered.skip(_page * _pageSize).take(_pageSize).toList();
 
     return IICard(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
@@ -624,10 +747,7 @@ class _CdpsTableState extends State<_CdpsTable> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                'CDPs (${widget.asset.asset})',
-                style: styles.cardTitle,
-              ),
+              Text('CDPs (${widget.asset.asset})', style: styles.cardTitle),
               Text(
                 '${filtered.length} positions',
                 style: styles.bodySm.copyWith(color: colors.textMuted),
@@ -638,8 +758,10 @@ class _CdpsTableState extends State<_CdpsTable> {
           if (filtered.isEmpty)
             Padding(
               padding: const EdgeInsets.all(16),
-              child: Text('No CDPs in this tier.',
-                  style: styles.bodyMd.copyWith(color: colors.textMuted)),
+              child: Text(
+                'No CDPs in this tier.',
+                style: styles.bodyMd.copyWith(color: colors.textMuted),
+              ),
             )
           else ...[
             Expanded(
@@ -648,83 +770,93 @@ class _CdpsTableState extends State<_CdpsTable> {
                 child: SizedBox(
                   width: double.infinity,
                   child: DataTable(
-                columnSpacing: 12,
-                headingRowHeight: 32,
-                dataRowMinHeight: 28,
-                dataRowMaxHeight: 36,
-                columns: [
-                  _col('Owner', styles, colors),
-                  _col('Collateral', styles, colors),
-                  _col('Minted', styles, colors),
-                  _col('CR%', styles, colors),
-                  _col('Liq. Price', styles, colors),
-                  _col('Drop %', styles, colors),
-                ],
-                rows: pageItems.map((cdp) {
-                  final cr = widget.crOf(cdp);
-                  final liq = _liqPrice(cdp);
-                  final drop = widget.assetPriceAda > 0
-                      ? (1 - liq / widget.assetPriceAda) * 100
-                      : 0.0;
-                  final owner = cdp.owner.length > 12
-                      ? '${cdp.owner.substring(0, 6)}…${cdp.owner.substring(cdp.owner.length - 6)}'
-                      : cdp.owner;
-                  final monoStyle = styles.monoSm.copyWith(color: colors.textSecondary);
-                  final isCopied = _copiedOwner == cdp.owner;
-                  return DataRow(
-                    cells: [
-                      DataCell(
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(owner, style: monoStyle),
-                            const SizedBox(width: 4),
-                            Tooltip(
-                              message: isCopied ? 'Copied!' : 'Copy address',
-                              child: InkWell(
-                                onTap: () => _copy(cdp.owner),
-                                borderRadius: BorderRadius.circular(4),
-                                child: Padding(
-                                  padding: const EdgeInsets.all(2),
-                                  child: Icon(
-                                    isCopied ? Icons.check : Icons.copy_outlined,
-                                    size: 12,
-                                    color: isCopied ? colors.success : colors.textMuted,
+                    columnSpacing: 12,
+                    headingRowHeight: 32,
+                    dataRowMinHeight: 28,
+                    dataRowMaxHeight: 36,
+                    columns: [
+                      _col('Owner', styles, colors),
+                      _col('Collateral', styles, colors),
+                      _col('Minted', styles, colors),
+                      _col('CR%', styles, colors),
+                      _col('Liq. Price', styles, colors),
+                      _col('Drop %', styles, colors),
+                    ],
+                    rows: pageItems.map((cdp) {
+                      final cr = widget.crOf(cdp);
+                      final liq = _liqPrice(cdp);
+                      final drop = _dropToLiq(cdp);
+                      final collLabel = collateralLabel(cdp.collateralAsset);
+                      final owner = cdp.owner.length > 12
+                          ? '${cdp.owner.substring(0, 6)}…${cdp.owner.substring(cdp.owner.length - 6)}'
+                          : cdp.owner;
+                      final monoStyle =
+                          styles.monoSm.copyWith(color: colors.textSecondary);
+                      final isCopied = _copiedOwner == cdp.owner;
+                      return DataRow(
+                        cells: [
+                          DataCell(
+                            Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(owner, style: monoStyle),
+                                const SizedBox(width: 4),
+                                Tooltip(
+                                  message: isCopied ? 'Copied!' : 'Copy address',
+                                  child: InkWell(
+                                    onTap: () => _copy(cdp.owner),
+                                    borderRadius: BorderRadius.circular(4),
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(2),
+                                      child: Icon(
+                                        isCopied
+                                            ? Icons.check
+                                            : Icons.copy_outlined,
+                                        size: 12,
+                                        color: isCopied
+                                            ? colors.success
+                                            : colors.textMuted,
+                                      ),
+                                    ),
                                   ),
                                 ),
-                              ),
+                              ],
                             ),
-                          ],
-                        ),
-                      ),
-                      DataCell(Text(
-                        '${numberFormatter(cdp.collateralAmount, 0)} ADA',
-                        style: monoStyle.copyWith(color: const Color(0xFF0288D1)),
-                      )),
-                      DataCell(Text(
-                        '${numberFormatter(cdp.mintedAmount, 2)} ${widget.asset.asset}',
-                        style: monoStyle.copyWith(color: colors.primary),
-                      )),
-                      DataCell(Text(
-                        '${cr.toStringAsFixed(1)}%',
-                        style: styles.monoSm.copyWith(
-                          color: _crColor(cr, colors),
-                          fontWeight: FontWeight.w600,
-                        ),
-                      )),
-                      DataCell(Text(numberFormatter(liq, 4), style: monoStyle)),
-                      DataCell(Text(
-                        '${drop.toStringAsFixed(1)}%',
-                        style: styles.monoSm.copyWith(
-                          color: drop > 15 ? colors.error : colors.textSecondary,
-                        ),
-                      )),
-                    ],
-                  );
-                }                ).toList(),
+                          ),
+                          DataCell(Text(
+                            '${numberFormatter(cdp.collateralAmount, 0)} $collLabel',
+                            style: monoStyle.copyWith(
+                                color: const Color(0xFF0288D1)),
+                          )),
+                          DataCell(Text(
+                            '${numberFormatter(cdp.mintedAmount, 2)} ${widget.asset.asset}',
+                            style: monoStyle.copyWith(color: colors.primary),
+                          )),
+                          DataCell(Text(
+                            '${cr.toStringAsFixed(1)}%',
+                            style: styles.monoSm.copyWith(
+                              color: _crColor(cdp, cr, colors),
+                              fontWeight: FontWeight.w600,
+                            ),
+                          )),
+                          DataCell(Text(
+                            '${numberFormatter(liq, 4)} $collLabel',
+                            style: monoStyle,
+                          )),
+                          DataCell(Text(
+                            '${drop.toStringAsFixed(1)}%',
+                            style: styles.monoSm.copyWith(
+                              color: drop > 15
+                                  ? colors.error
+                                  : colors.textSecondary,
+                            ),
+                          )),
+                        ],
+                      );
+                    }).toList(),
+                  ),
+                ),
               ),
-            ),
-            ),
             ),
             if (totalPages > 1)
               Row(

--- a/lib/views/insights/cdp_explorer/cdp_explorer_insights.dart
+++ b/lib/views/insights/cdp_explorer/cdp_explorer_insights.dart
@@ -584,17 +584,17 @@ class _CdpsTableState extends State<_CdpsTable> {
   }
 
   double _liqPrice(Cdp cdp) {
-    if (cdp.mintedAmount <= 0) return 0;
-    return cdp.collateralAmount / (cdp.mintedAmount * (widget.asset.liquidationRatio / 100));
+    if (cdp.mintedAmount <= 0 || widget.asset.liquidationRatio == null) return 0;
+    return cdp.collateralAmount / (cdp.mintedAmount * (widget.asset.liquidationRatio! / 100));
   }
 
   Color _crColor(double cr, AppColorScheme colors) {
     final liq = widget.asset.liquidationRatio;
     final mcr = widget.asset.maintenanceRatio;
     final rmr = widget.asset.rmr;
-    if (cr < liq) return colors.error;
-    if (cr < mcr) return const Color(0xFFE64A19);
-    if (cr < rmr) return colors.warning;
+    if (liq != null && cr < liq) return colors.error;
+    if (mcr != null && cr < mcr) return const Color(0xFFE64A19);
+    if (rmr != null && cr < rmr) return colors.warning;
     if (cr < 200) return const Color(0xFF0288D1);
     return colors.success;
   }

--- a/lib/views/insights/dashboard/protocol_dashboard.dart
+++ b/lib/views/insights/dashboard/protocol_dashboard.dart
@@ -450,10 +450,12 @@ class _AssetHealthCard extends StatelessWidget {
     Color crColor(double cr) {
       final asset = indigoAsset;
       if (asset != null) {
-        if (cr >= asset.maintenanceRatio + 20) return colors.success;
-        if (cr >= asset.maintenanceRatio) return colors.warning;
-        if (cr >= asset.liquidationRatio) return colors.warning;
-        return colors.error;
+        final mcr = asset.maintenanceRatio;
+        final lr = asset.liquidationRatio;
+        if (mcr != null && cr >= mcr + 20) return colors.success;
+        if (mcr != null && cr >= mcr) return colors.warning;
+        if (lr != null && cr >= lr) return colors.warning;
+        if (mcr != null || lr != null) return colors.error;
       }
       // Fallback if IndigoAsset not available
       if (cr >= 200) return colors.success;

--- a/lib/views/insights/indy_staking/indy_staking_insights.dart
+++ b/lib/views/insights/indy_staking/indy_staking_insights.dart
@@ -18,7 +18,7 @@ import 'package:indigo_insights/widgets/ii_tab_bar.dart';
 import 'package:indigo_insights/widgets/ii_top_bar.dart';
 
 /// Tab name constants for URL routing (`?tab=stake-history` etc.)
-const _kStakingTabs = ['stake-history', 'staking-velocity', 'governance-rewards'];
+const _kStakingTabs = ['stake-history', 'staking-trends', 'governance-rewards'];
 
 class IndyStakingInsights extends StatefulWidget {
   const IndyStakingInsights({super.key, this.initialTab});
@@ -190,7 +190,7 @@ class _StakingContent extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
             child: IITabBar(
-              tabs: const ['Staked History', 'Velocity', 'Gov. Rewards'],
+              tabs: const ['Staked History', 'Trends', 'Gov. Rewards'],
               controller: tabController,
               onTap: (i) => context.goTab(_kStakingTabs[i]),
             ),

--- a/lib/views/insights/indy_staking/stake_history_chart.dart
+++ b/lib/views/insights/indy_staking/stake_history_chart.dart
@@ -12,9 +12,10 @@ class StakeHistoryChart extends StatelessWidget {
 
   List<AmountDateData> _getStakeHistoriesData(List<StakeHistory> stakeHistories) {
     final data = stakeHistories
+        .sortedBy((item) => item.date)
         .groupFoldBy<DateTime, double>(
           (item) => DateTime(item.date.year, item.date.month, item.date.day),
-          (a, b) => (a ?? 0) + b.staked,
+          (_, b) => b.staked, // tS is a total snapshot, keep the last (most recent) per day
         )
         .entries
         .map((entry) => AmountDateData(entry.key, entry.value))

--- a/lib/views/insights/indy_staking/staking_velocity_chart.dart
+++ b/lib/views/insights/indy_staking/staking_velocity_chart.dart
@@ -1,11 +1,16 @@
 import 'package:collection/collection.dart';
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:indigo_insights/models/stake_history.dart';
 import 'package:indigo_insights/repositories/stake_history_repository.dart';
 import 'package:indigo_insights/service_locator.dart';
+import 'package:indigo_insights/theme/app_color_scheme.dart';
+import 'package:indigo_insights/theme/app_text_styles.dart';
 import 'package:indigo_insights/theme/color_scheme.dart';
 import 'package:indigo_insights/utils/async_builder.dart';
+import 'package:indigo_insights/utils/formatters.dart';
+import 'package:intl/intl.dart' as intl;
 import 'package:indigo_insights/widgets/amount_date_chart.dart';
 
 class StakingVelocityChart extends StatelessWidget {
@@ -20,63 +25,217 @@ class StakingVelocityChart extends StatelessWidget {
           return const Center(child: Text('Not enough data.'));
         }
         final sorted = history.sortedBy((s) => s.date);
-        return _VelocityChart(history: sorted);
+        return _TrendChart(history: sorted);
       },
       errorBuilder: (error, retry) => Text(error.toString()),
     );
   }
 }
 
-class _VelocityChart extends StatelessWidget {
+class _TrendChart extends StatelessWidget {
   final List<StakeHistory> history;
-  const _VelocityChart({required this.history});
+  const _TrendChart({required this.history});
 
-  List<AmountDateData> _buildDailyDeltas() {
-    // Group by day, take last entry per day
+  static const _windowDays = 14;
+
+  List<AmountDateData> _buildSmoothedTrend() {
     final byDay = history.groupFoldBy<DateTime, StakeHistory>(
       (s) => DateTime(s.date.year, s.date.month, s.date.day),
-      (prev, curr) => (prev == null || curr.date.isAfter(prev.date))
-          ? curr
-          : prev,
+      (prev, curr) =>
+          (prev == null || curr.date.isAfter(prev.date)) ? curr : prev,
     );
 
     final days = byDay.keys.toList()..sort();
-    final result = <AmountDateData>[];
 
+    final deltas = <double>[];
+    final deltaDates = <DateTime>[];
     for (int i = 1; i < days.length; i++) {
       final prev = byDay[days[i - 1]]!.staked;
       final curr = byDay[days[i]]!.staked;
-      result.add(AmountDateData(days[i], curr - prev));
+      deltas.add(curr - prev);
+      deltaDates.add(days[i]);
+    }
+
+    final result = <AmountDateData>[];
+    for (int i = 0; i < deltas.length; i++) {
+      final start = (i - _windowDays + 1).clamp(0, i);
+      final window = deltas.sublist(start, i + 1);
+      final avg = window.reduce((a, b) => a + b) / window.length;
+      result.add(AmountDateData(deltaDates[i], avg));
     }
     return result;
   }
 
   @override
   Widget build(BuildContext context) {
-    final deltas = _buildDailyDeltas();
-    if (deltas.isEmpty) return const SizedBox.shrink();
+    final trend = _buildSmoothedTrend();
+    if (trend.isEmpty) return const SizedBox.shrink();
 
-    final positiveData = deltas.map((d) => AmountDateData(d.date, d.amount.clamp(0, double.infinity))).toList();
-    final negativeData = deltas.map((d) => AmountDateData(d.date, d.amount.clamp(-double.infinity, 0))).toList();
+    final appColors = AppColorScheme.of(context);
+    final styles = AppTextStyles.of(context);
 
-    return AmountDateChart(
-      title: 'Staking Velocity (Daily Delta)',
-      data: [positiveData, negativeData],
-      colors: [onSuccess, primaryRed],
-      gradients: [
-        LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [onSuccess.withValues(alpha: 0.4), onSuccess.withValues(alpha: 0.05)],
+    final spots = trend
+        .map((d) => FlSpot(
+              d.date.millisecondsSinceEpoch.toDouble(),
+              d.amount,
+            ))
+        .toList();
+
+    final maxAbs = trend.map((d) => d.amount.abs()).reduce((a, b) => a > b ? a : b);
+    final abbreviation = getAbbreviation(maxAbs);
+
+    final minX = trend.first.date.millisecondsSinceEpoch.toDouble();
+    final maxX = trend.last.date.millisecondsSinceEpoch.toDouble();
+    final totalDays = trend.last.date.difference(trend.first.date).inDays;
+    final dateIntervalDays = (totalDays / 6).ceil();
+
+    DateTime? previousDateLabel;
+
+    return Column(
+      children: [
+        Container(
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.only(top: 8, left: 30, right: 16),
+          child: Row(
+            children: [
+              Text('Staking Trends (14-Day Average)', style: styles.cardTitle)
+                  .animate()
+                  .fade(duration: 300.ms),
+              const Spacer(),
+              Text('Net Staking', style: styles.bodyMd.copyWith(color: onSuccess, fontWeight: FontWeight.w600)),
+              const SizedBox(width: 8),
+              Text('Net Unstaking', style: styles.bodyMd.copyWith(color: primaryRed, fontWeight: FontWeight.w600)),
+            ],
+          ),
         ),
-        LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [primaryRed.withValues(alpha: 0.4), primaryRed.withValues(alpha: 0.05)],
+        Expanded(
+          child: LineChart(
+            LineChartData(
+              minX: minX,
+              maxX: maxX,
+              minY: -maxAbs * 1.2,
+              maxY: maxAbs * 1.2,
+              lineBarsData: [
+                LineChartBarData(
+                  spots: spots,
+                  isCurved: true,
+                  curveSmoothness: 0.3,
+                  color: Colors.white.withValues(alpha: 0.85),
+                  barWidth: 1.5,
+                  dotData: const FlDotData(show: false),
+                  // Green fill: below the line where value > 0, capped at y=0
+                  belowBarData: BarAreaData(
+                    show: true,
+                    cutOffY: 0,
+                    applyCutOffY: true,
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        onSuccess.withValues(alpha: 0.55),
+                        onSuccess.withValues(alpha: 0.05),
+                      ],
+                    ),
+                  ),
+                  // Red fill: above the line where value < 0, capped at y=0
+                  aboveBarData: BarAreaData(
+                    show: true,
+                    cutOffY: 0,
+                    applyCutOffY: true,
+                    gradient: LinearGradient(
+                      begin: Alignment.bottomCenter,
+                      end: Alignment.topCenter,
+                      colors: [
+                        primaryRed.withValues(alpha: 0.55),
+                        primaryRed.withValues(alpha: 0.05),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              gridData: const FlGridData(show: true),
+              borderData: FlBorderData(show: true),
+              extraLinesData: ExtraLinesData(
+                horizontalLines: [
+                  HorizontalLine(
+                    y: 0,
+                    color: appColors.textMuted.withValues(alpha: 0.5),
+                    strokeWidth: 1,
+                    dashArray: [6, 4],
+                  ),
+                ],
+              ),
+              titlesData: FlTitlesData(
+                topTitles: AxisTitles(
+                  sideTitles: SideTitles(reservedSize: 15, showTitles: true, getTitlesWidget: (v, m) => const Text('')),
+                ),
+                leftTitles: AxisTitles(
+                  sideTitles: SideTitles(reservedSize: 30, showTitles: true, getTitlesWidget: (v, m) => const Text('')),
+                ),
+                bottomTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    interval: Duration(days: dateIntervalDays).inMilliseconds.toDouble(),
+                    showTitles: true,
+                    reservedSize: 36,
+                    getTitlesWidget: (value, meta) {
+                      final date = DateTime.fromMillisecondsSinceEpoch(value.toInt()).toUtc();
+                      final day = DateTime(date.year, date.month, date.day);
+                      if (previousDateLabel != null &&
+                          day.difference(previousDateLabel!).inDays.abs() < dateIntervalDays) {
+                        previousDateLabel = day;
+                        return const SizedBox();
+                      }
+                      previousDateLabel = day;
+                      return SideTitleWidget(
+                        meta: meta,
+                        child: Text(
+                          '${day.month}/${day.year.toString().substring(2)}',
+                          style: styles.monoSm.copyWith(color: appColors.textMuted),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                rightTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    reservedSize: 72,
+                    showTitles: true,
+                    getTitlesWidget: (value, meta) {
+                      if (value == meta.min || value == meta.max) return const SizedBox();
+                      return Padding(
+                        padding: const EdgeInsets.only(left: 8),
+                        child: Text(
+                          '${numberAbbreviated(value, abbreviation).toStringAsFixed(1)}${abbreviation?.name ?? ''}',
+                          style: styles.monoSm.copyWith(color: appColors.textMuted),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+              lineTouchData: LineTouchData(
+                touchTooltipData: LineTouchTooltipData(
+                  fitInsideHorizontally: true,
+                  fitInsideVertically: true,
+                  getTooltipColor: (_) => appColors.surface,
+                  getTooltipItems: (spots) => spots.map((s) {
+                    final date = DateTime.fromMillisecondsSinceEpoch(s.x.toInt());
+                    final isPositive = s.y >= 0;
+                    return LineTooltipItem(
+                      '${intl.DateFormat('yyyy/MM/dd').format(date)}\n${isPositive ? '+' : ''}${numberFormatter(s.y, 0)} INDY',
+                      styles.bodySm.copyWith(
+                        color: isPositive ? onSuccess : primaryRed,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    );
+                  }).toList(),
+                ),
+                handleBuiltInTouches: true,
+              ),
+            ),
+          ).animate().fade(duration: 500.ms, curve: Curves.easeInOut),
         ),
       ],
-      labels: ['Staked', 'Unstaked'],
-      currency: 'INDY',
-    ).animate().fade(duration: 500.ms);
+    );
   }
 }

--- a/lib/views/insights/liquidation/cumulative_liquidations_chart.dart
+++ b/lib/views/insights/liquidation/cumulative_liquidations_chart.dart
@@ -17,6 +17,8 @@ class CumulativeLiquidationsChart extends StatelessWidget {
     final liquidations = data.where((l) => l.asset == indigoAsset.asset).toList()
       ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
 
+    if (liquidations.isEmpty) return [];
+
     double cumulativeSum = 0.0;
     final liqData = liquidations
         .groupFoldBy<DateTime, double>(
@@ -46,6 +48,12 @@ class CumulativeLiquidationsChart extends StatelessWidget {
       fetcher: () => sl<LiquidationRepository>().getLiquidations(),
       builder: (liquidations) {
         liquidations.sortBy((l) => l.createdAt);
+
+        final assetData = _getCumulativeLiquidationsData(liquidations);
+        if (assetData.isEmpty || liquidations.isEmpty) {
+          return const Center(child: Text('No liquidations recorded for this asset.'));
+        }
+
         final startDate = liquidations.first.createdAt.add(const Duration(days: -1));
         final endDate = liquidations.last.createdAt.add(const Duration(days: -1));
 
@@ -53,13 +61,7 @@ class CumulativeLiquidationsChart extends StatelessWidget {
           title: 'Cumulative Liquidations',
           currency: 'ADA',
           labels: [indigoAsset.asset],
-          data: [
-            normalizeAmountDateData(
-              _getCumulativeLiquidationsData(liquidations),
-              startDate,
-              endDate,
-            ),
-          ],
+          data: [normalizeAmountDateData(assetData, startDate, endDate)],
           colors: [getColorByAsset(indigoAsset.asset)],
           gradients: [getGradientByAsset(indigoAsset.asset)],
         );

--- a/lib/views/insights/liquidation/liquidation_information.dart
+++ b/lib/views/insights/liquidation/liquidation_information.dart
@@ -85,7 +85,7 @@ class LiquidationInformation extends StatelessWidget {
                 liquidations
                     .map(
                       (c) =>
-                          (c.collateralAbsorbed * 0.98 - c.iAssetBurned * c.oraclePrice),
+                          (c.collateralAbsorbed * 0.98 - c.iAssetBurned * (c.oraclePrice ?? 0.0)),
                     )
                     .reduce((value, element) => value + element),
                 context,

--- a/lib/views/insights/liquidation/liquidation_information.dart
+++ b/lib/views/insights/liquidation/liquidation_information.dart
@@ -35,6 +35,20 @@ class LiquidationInformation extends StatelessWidget {
       builder: (liquidations) {
         liquidations.sortBy((liq) => liq.createdAt);
 
+        if (liquidations.isEmpty) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '${indigoAsset.asset} Liquidations',
+                style: AppTextStyles.of(context).cardTitle,
+              ),
+              const SizedBox(height: 32),
+              const Text('No liquidations recorded for this asset.'),
+            ],
+          );
+        }
+
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -83,11 +97,8 @@ class LiquidationInformation extends StatelessWidget {
               'SP ADA Rewards (Total)',
               assetAmount(
                 liquidations
-                    .map(
-                      (c) =>
-                          (c.collateralAbsorbed * 0.98 - c.iAssetBurned * (c.oraclePrice ?? 0.0)),
-                    )
-                    .reduce((value, element) => value + element),
+                    .map((c) => c.collateralAbsorbed * 0.98 - c.iAssetBurned * (c.oraclePrice ?? 0.0))
+                    .fold(0.0, (a, b) => a + b),
                 context,
               ),
             ),
@@ -95,7 +106,7 @@ class LiquidationInformation extends StatelessWidget {
             informationRow(
               'Governance ADA Rewards (Total)',
               assetAmount(
-                liquidations.map((c) => c.collateralAbsorbed * 0.02).reduce((a, b) => a + b),
+                liquidations.map((c) => c.collateralAbsorbed * 0.02).fold(0.0, (a, b) => a + b),
                 context,
               ),
             ),

--- a/lib/views/insights/position_simulator/position_simulator_insights.dart
+++ b/lib/views/insights/position_simulator/position_simulator_insights.dart
@@ -2,11 +2,10 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:indigo_insights/models/asset_interest_rate.dart';
 import 'package:indigo_insights/models/asset_price.dart';
+import 'package:indigo_insights/models/collateral_pair.dart';
 import 'package:indigo_insights/models/indigo_asset.dart';
 import 'package:indigo_insights/repositories/asset_price_repository.dart';
-import 'package:indigo_insights/repositories/cdp_repository.dart';
 import 'package:indigo_insights/repositories/indigo_asset_repository.dart';
 import 'package:indigo_insights/service_locator.dart';
 import 'package:indigo_insights/theme/app_color_scheme.dart';
@@ -21,7 +20,6 @@ import 'package:indigo_insights/widgets/ii_top_bar.dart';
 typedef _SimulatorData = ({
   List<IndigoAsset> assets,
   List<AssetPrice> prices,
-  List<AssetInterestRate> rates,
 });
 
 class PositionSimulatorInsights extends StatelessWidget {
@@ -43,12 +41,10 @@ class PositionSimulatorInsights extends StatelessWidget {
                     final results = await Future.wait([
                       sl<IndigoAssetRepository>().getAssets(),
                       sl<AssetPriceRepository>().getPrices(),
-                      sl<CdpRepository>().getAssetInterestRates(),
                     ]);
                     return (
                       assets: results[0] as List<IndigoAsset>,
                       prices: results[1] as List<AssetPrice>,
-                      rates: results[2] as List<AssetInterestRate>,
                     );
                   },
                   builder: (data) => _SimulatorLayout(data: data),
@@ -64,7 +60,7 @@ class PositionSimulatorInsights extends StatelessWidget {
   }
 }
 
-// ─── Single stateful layout — no prop-drilling ───────────────────────────────
+// ─── Stateful layout ──────────────────────────────────────────────────────────
 
 class _SimulatorLayout extends StatefulWidget {
   final _SimulatorData data;
@@ -78,6 +74,7 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
     with SingleTickerProviderStateMixin {
   late TabController _assetTabController;
   int _selectedAssetIndex = 0;
+  String _selectedCollateral = ''; // '' = ADA
   final _collateralCtrl = TextEditingController(text: '10000');
   final _mintedCtrl = TextEditingController(text: '1000');
 
@@ -90,7 +87,15 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
     );
     _assetTabController.addListener(() {
       if (!_assetTabController.indexIsChanging) {
-        setState(() => _selectedAssetIndex = _assetTabController.index);
+        final newAsset = widget.data.assets[_assetTabController.index];
+        setState(() {
+          _selectedAssetIndex = _assetTabController.index;
+          // Default to ADA pair when switching assets.
+          _selectedCollateral =
+              newAsset.collateralAssets.any((p) => p.collateralAsset.isEmpty)
+                  ? ''
+                  : newAsset.collateralAssets.firstOrNull?.collateralAsset ?? '';
+        });
       }
     });
   }
@@ -105,17 +110,26 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
 
   IndigoAsset get _asset => widget.data.assets[_selectedAssetIndex];
 
-  double get _price =>
-      widget.data.prices
-          .firstWhereOrNull((p) => p.asset == _asset.asset)
-          ?.price ??
-      1.0;
+  CollateralPair? get _pair =>
+      _asset.collateralAssets
+          .firstWhereOrNull((p) => p.collateralAsset == _selectedCollateral) ??
+      _asset.collateralAssets.firstOrNull;
 
-  double get _interestRate =>
-      widget.data.rates
-          .firstWhereOrNull((r) => r.asset == _asset.asset)
-          ?.interestRate ??
-      0.0;
+  String get _collLabel => collateralLabel(_selectedCollateral);
+
+  double get _price {
+    final match = widget.data.prices.firstWhereOrNull(
+      (p) => p.asset == _asset.asset && p.collateralAsset == _selectedCollateral,
+    );
+    return match?.price ??
+        widget.data.prices
+            .firstWhereOrNull((p) => p.asset == _asset.asset)
+            ?.price ??
+        1.0;
+  }
+
+  // interestRate from CollateralPair is a decimal fraction (e.g. 0.035 = 3.5%).
+  double get _interestRate => _pair?.interestRate ?? 0.0;
 
   double get _collateral => double.tryParse(_collateralCtrl.text) ?? 0.0;
   double get _minted => double.tryParse(_mintedCtrl.text) ?? 0.0;
@@ -126,18 +140,21 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
   }
 
   double get _liqPrice {
-    if (_minted <= 0 || _asset.liquidationRatio == null) return 0;
-    return _collateral / (_minted * (_asset.liquidationRatio! / 100));
+    final pair = _pair;
+    if (_minted <= 0 || pair == null) return 0;
+    return _collateral / (_minted * (pair.liquidationRatioPercent / 100));
   }
 
   double get _maintenancePrice {
-    if (_minted <= 0 || _asset.maintenanceRatio == null) return 0;
-    return _collateral / (_minted * (_asset.maintenanceRatio! / 100));
+    final pair = _pair;
+    if (_minted <= 0 || pair == null) return 0;
+    return _collateral / (_minted * (pair.maintenanceRatioPercent / 100));
   }
 
   double get _rmrPrice {
-    if (_minted <= 0 || _asset.rmr == null) return 0;
-    return _collateral / (_minted * (_asset.rmr! / 100));
+    final pair = _pair;
+    if (_minted <= 0 || pair == null) return 0;
+    return _collateral / (_minted * (pair.redemptionRatioPercent / 100));
   }
 
   double get _dropToLiq {
@@ -145,7 +162,7 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
     return ((_price - _liqPrice) / _price) * 100;
   }
 
-  double _adaToReachCr(double targetCr) {
+  double _collateralToReachCr(double targetCr) {
     if (_minted <= 0) return 0;
     final needed = _minted * _price * (targetCr / 100);
     return (needed - _collateral).clamp(0, double.infinity);
@@ -161,10 +178,33 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
+    final pair = _pair;
 
     return LayoutBuilder(
       builder: (context, constraints) {
         final isWide = constraints.maxWidth > 700;
+
+        // Collateral selector chips — only shown when > 1 collateral type.
+        Widget? collateralSelector;
+        if (_asset.collateralAssets.length > 1) {
+          collateralSelector = Wrap(
+            spacing: 8,
+            children: _asset.collateralAssets.map((p) {
+              final isSelected = p.collateralAsset == _selectedCollateral;
+              return ChoiceChip(
+                label: Text(collateralLabel(p.collateralAsset)),
+                selected: isSelected,
+                onSelected: (_) =>
+                    setState(() => _selectedCollateral = p.collateralAsset),
+                selectedColor: colors.primary.withValues(alpha: 0.2),
+                labelStyle: styles.bodySm.copyWith(
+                  color: isSelected ? colors.primary : colors.textSecondary,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                ),
+              );
+            }).toList(),
+          );
+        }
 
         final header = Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -178,9 +218,13 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
               controller: _assetTabController,
               tabs: widget.data.assets.map((a) => a.asset).toList(),
             ),
+            if (collateralSelector != null) ...[
+              const SizedBox(height: 8),
+              collateralSelector,
+            ],
             const SizedBox(height: 8),
             Text(
-              'Current ${_asset.asset} price: ${numberFormatter(_price, 4)} ADA',
+              'Current ${_asset.asset} price: ${numberFormatter(_price, 4)} $_collLabel',
               style: styles.bodySm.copyWith(color: colors.textSecondary),
             ),
             const SizedBox(height: 14),
@@ -195,7 +239,7 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
               child: Column(
                 children: [
                   _NumField(
-                    label: 'Collateral (ADA)',
+                    label: 'Collateral ($_collLabel)',
                     controller: _collateralCtrl,
                     onChanged: (_) => setState(() {}),
                   ),
@@ -219,17 +263,17 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
                   ),
                   _MetricRow(
                     'Liquidation Price',
-                    '${numberFormatter(_liqPrice, 4)} ADA',
+                    '${numberFormatter(_liqPrice, 4)} $_collLabel',
                     color: colors.error,
                   ),
                   _MetricRow(
                     'Maintenance Price',
-                    '${numberFormatter(_maintenancePrice, 4)} ADA',
+                    '${numberFormatter(_maintenancePrice, 4)} $_collLabel',
                     color: colors.warning,
                   ),
                   _MetricRow(
                     'RMR Price',
-                    '${numberFormatter(_rmrPrice, 4)} ADA',
+                    '${numberFormatter(_rmrPrice, 4)} $_collLabel',
                     color: colors.warning,
                   ),
                   _MetricRow(
@@ -247,7 +291,7 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
                   const SizedBox(height: 4),
                   _MetricRow(
                     'Add Collateral',
-                    '${numberFormatter(_adaToReachCr(200), 0)} ADA',
+                    '${numberFormatter(_collateralToReachCr(200), 0)} $_collLabel',
                   ),
                   _MetricRow(
                     'Or Repay Debt',
@@ -266,9 +310,9 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
               title: 'Safety Gauge',
               child: _GaugeContent(
                 cr: _cr.isInfinite ? 999 : _cr,
-                liqRatio: _asset.liquidationRatio,
-                mcr: _asset.maintenanceRatio,
-                rmr: _asset.rmr,
+                liqRatio: pair?.liquidationRatioPercent,
+                mcr: pair?.maintenanceRatioPercent,
+                rmr: pair?.redemptionRatioPercent,
               ),
             ),
             const SizedBox(height: 12),
@@ -280,10 +324,12 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
                     child: _SectionCard(
                       title: 'Price Scenario Table',
                       child: _ScenarioTable(
-                        asset: _asset,
+                        pair: pair,
                         collateral: _collateral,
                         minted: _minted,
                         currentPrice: _price,
+                        iAsset: _asset.asset,
+                        collLabel: _collLabel,
                       ),
                     ),
                   ),
@@ -293,10 +339,11 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
                       child: _SectionCard(
                         title: 'Interest Cost Projection',
                         child: _InterestProjection(
-                          asset: _asset,
+                          iAsset: _asset.asset,
                           minted: _minted,
                           interestRate: _interestRate,
                           currentPrice: _price,
+                          collLabel: _collLabel,
                         ),
                       ),
                     ),
@@ -307,10 +354,12 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
               _SectionCard(
                 title: 'Price Scenario Table',
                 child: _ScenarioTable(
-                  asset: _asset,
+                  pair: pair,
                   collateral: _collateral,
                   minted: _minted,
                   currentPrice: _price,
+                  iAsset: _asset.asset,
+                  collLabel: _collLabel,
                 ),
               ),
               if (_interestRate > 0) ...[
@@ -318,10 +367,11 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
                 _SectionCard(
                   title: 'Interest Cost Projection',
                   child: _InterestProjection(
-                    asset: _asset,
+                    iAsset: _asset.asset,
                     minted: _minted,
                     interestRate: _interestRate,
                     currentPrice: _price,
+                    collLabel: _collLabel,
                   ),
                 ),
               ],
@@ -410,7 +460,6 @@ class _GaugeContent extends StatelessWidget {
       if (liqRatio != null && cr < liqRatio! + 10) return colors.error;
       if (mcr != null && cr < mcr!) return colors.warning;
       if (rmr != null && cr < rmr!) return colors.warning;
-      if (cr < 200) return colors.success;
       return colors.success;
     }
 
@@ -423,7 +472,6 @@ class _GaugeContent extends StatelessWidget {
     }
 
     final cappedCr = cr.clamp(0, 400).toDouble();
-    final fraction = cappedCr / 400;
     final color = zoneColor();
 
     return Column(
@@ -439,7 +487,7 @@ class _GaugeContent extends StatelessWidget {
         ClipRRect(
           borderRadius: BorderRadius.circular(8),
           child: LinearProgressIndicator(
-            value: fraction,
+            value: cappedCr / 400,
             backgroundColor: colors.canvas,
             valueColor: AlwaysStoppedAnimation(color),
             minHeight: 20,
@@ -456,12 +504,18 @@ class _GaugeContent extends StatelessWidget {
           ),
         ),
         const Divider(height: 20),
-        if (liqRatio != null) _ThresholdRow('Liquidation (LR)', liqRatio!, colors.error)
-        else _ThresholdRowNA('Liquidation (LR)', colors.textMuted),
-        if (mcr != null) _ThresholdRow('Maintenance (MCR)', mcr!, colors.warning)
-        else _ThresholdRowNA('Maintenance (MCR)', colors.textMuted),
-        if (rmr != null) _ThresholdRow('Redemption (RMR)', rmr!, colors.warning)
-        else _ThresholdRowNA('Redemption (RMR)', colors.textMuted),
+        if (liqRatio != null)
+          _ThresholdRow('Liquidation (LR)', liqRatio!, colors.error)
+        else
+          _ThresholdRowNA('Liquidation (LR)', colors.textMuted),
+        if (mcr != null)
+          _ThresholdRow('Maintenance (MCR)', mcr!, colors.warning)
+        else
+          _ThresholdRowNA('Maintenance (MCR)', colors.textMuted),
+        if (rmr != null)
+          _ThresholdRow('Redemption (RMR)', rmr!, colors.warning)
+        else
+          _ThresholdRowNA('Redemption (RMR)', colors.textMuted),
       ],
     );
   }
@@ -470,23 +524,31 @@ class _GaugeContent extends StatelessWidget {
 // ─── Scenario Table ───────────────────────────────────────────────────────────
 
 class _ScenarioTable extends StatelessWidget {
-  final IndigoAsset asset;
+  final CollateralPair? pair;
   final double collateral;
   final double minted;
   final double currentPrice;
+  final String iAsset;
+  final String collLabel;
 
   const _ScenarioTable({
-    required this.asset,
+    required this.pair,
     required this.collateral,
     required this.minted,
     required this.currentPrice,
+    required this.iAsset,
+    required this.collLabel,
   });
 
   @override
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
-    final drops = [0, 10, 20, 30, 40, 50];
+    const drops = [0, 10, 20, 30, 40, 50];
+
+    final liq = pair?.liquidationRatioPercent;
+    final mcr = pair?.maintenanceRatioPercent;
+    final rmr = pair?.redemptionRatioPercent;
 
     return SizedBox(
       width: double.infinity,
@@ -497,21 +559,18 @@ class _ScenarioTable extends StatelessWidget {
         dataRowMaxHeight: 32,
         columns: [
           DataColumn(label: Text('Drop', style: styles.monoSm)),
-          DataColumn(label: Text('Asset Price', style: styles.monoSm)),
+          DataColumn(label: Text('$collLabel Price', style: styles.monoSm)),
           DataColumn(label: Text('CR%', style: styles.monoSm)),
           DataColumn(label: Text('Status', style: styles.monoSm)),
         ],
         rows: drops.map((drop) {
           final simPrice = drop >= 100
               ? double.infinity
-              : currentPrice / (1 - drop / 100);
+              : currentPrice * (1 - drop / 100);
           double cr = double.infinity;
           if (minted > 0 && simPrice.isFinite && simPrice > 0) {
             cr = (collateral / simPrice / minted) * 100;
           }
-          final liq = asset.liquidationRatio;
-          final mcr = asset.maintenanceRatio;
-          final rmr = asset.rmr;
           final status = (liq != null && cr < liq)
               ? 'LIQUIDATED'
               : (mcr != null && cr < mcr)
@@ -530,7 +589,10 @@ class _ScenarioTable extends StatelessWidget {
             cells: [
               DataCell(Text('-$drop%', style: styles.monoSm)),
               DataCell(
-                Text(numberFormatter(simPrice, 4), style: styles.monoSm),
+                Text(
+                  simPrice.isFinite ? numberFormatter(simPrice, 4) : '—',
+                  style: styles.monoSm,
+                ),
               ),
               DataCell(
                 Text(
@@ -552,16 +614,19 @@ class _ScenarioTable extends StatelessWidget {
 // ─── Interest Projection ──────────────────────────────────────────────────────
 
 class _InterestProjection extends StatelessWidget {
-  final IndigoAsset asset;
+  final String iAsset;
   final double minted;
+  // Decimal fraction (e.g. 0.035 = 3.5% APR).
   final double interestRate;
   final double currentPrice;
+  final String collLabel;
 
   const _InterestProjection({
-    required this.asset,
+    required this.iAsset,
     required this.minted,
     required this.interestRate,
     required this.currentPrice,
+    required this.collLabel,
   });
 
   @override
@@ -569,16 +634,16 @@ class _InterestProjection extends StatelessWidget {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
 
-    ({double iAsset, double ada}) forDays(int days) {
-      final i = minted * (interestRate / 100) * (days / 365);
-      return (iAsset: i, ada: i * currentPrice);
+    ({double iAssetAmt, double collateral}) forDays(int days) {
+      final i = minted * interestRate * (days / 365);
+      return (iAssetAmt: i, collateral: i * currentPrice);
     }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Rate: ${interestRate.toStringAsFixed(2)}% APR',
+          'Rate: ${(interestRate * 100).toStringAsFixed(2)}% APR',
           style: styles.sectionLabel.copyWith(color: colors.textSecondary),
         ),
         const SizedBox(height: 8),
@@ -602,11 +667,11 @@ class _InterestProjection extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
                     Text(
-                      '${numberFormatter(entry.data.iAsset, 4)} ${asset.asset}',
+                      '${numberFormatter(entry.data.iAssetAmt, 4)} $iAsset',
                       style: styles.monoSm,
                     ),
                     Text(
-                      '≈ ${numberFormatter(entry.data.ada, 2)} ADA',
+                      '≈ ${numberFormatter(entry.data.collateral, 2)} $collLabel',
                       style: styles.monoSm.copyWith(
                         color: colors.textSecondary,
                       ),
@@ -673,10 +738,7 @@ class _MetricRow extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            label,
-            style: styles.bodySm.copyWith(color: colors.textSecondary),
-          ),
+          Text(label, style: styles.bodySm.copyWith(color: colors.textSecondary)),
           Text(
             value,
             style: styles.monoSm.copyWith(
@@ -726,10 +788,7 @@ class _ThresholdRow extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            label,
-            style: styles.bodySm.copyWith(color: colors.textSecondary),
-          ),
+          Text(label, style: styles.bodySm.copyWith(color: colors.textSecondary)),
           Text(
             '${value.toStringAsFixed(1)}%',
             style: styles.monoSm.copyWith(

--- a/lib/views/insights/position_simulator/position_simulator_insights.dart
+++ b/lib/views/insights/position_simulator/position_simulator_insights.dart
@@ -126,18 +126,18 @@ class _SimulatorLayoutState extends State<_SimulatorLayout>
   }
 
   double get _liqPrice {
-    if (_minted <= 0) return 0;
-    return _collateral / (_minted * (_asset.liquidationRatio / 100));
+    if (_minted <= 0 || _asset.liquidationRatio == null) return 0;
+    return _collateral / (_minted * (_asset.liquidationRatio! / 100));
   }
 
   double get _maintenancePrice {
-    if (_minted <= 0) return 0;
-    return _collateral / (_minted * (_asset.maintenanceRatio / 100));
+    if (_minted <= 0 || _asset.maintenanceRatio == null) return 0;
+    return _collateral / (_minted * (_asset.maintenanceRatio! / 100));
   }
 
   double get _rmrPrice {
-    if (_minted <= 0) return 0;
-    return _collateral / (_minted * (_asset.rmr / 100));
+    if (_minted <= 0 || _asset.rmr == null) return 0;
+    return _collateral / (_minted * (_asset.rmr! / 100));
   }
 
   double get _dropToLiq {
@@ -390,9 +390,9 @@ class _SectionCard extends StatelessWidget {
 
 class _GaugeContent extends StatelessWidget {
   final double cr;
-  final double liqRatio;
-  final double mcr;
-  final double rmr;
+  final double? liqRatio;
+  final double? mcr;
+  final double? rmr;
 
   const _GaugeContent({
     required this.cr,
@@ -407,17 +407,17 @@ class _GaugeContent extends StatelessWidget {
     final styles = AppTextStyles.of(context);
 
     Color zoneColor() {
-      if (cr < liqRatio + 10) return colors.error;
-      if (cr < mcr) return colors.warning;
-      if (cr < rmr) return colors.warning;
+      if (liqRatio != null && cr < liqRatio! + 10) return colors.error;
+      if (mcr != null && cr < mcr!) return colors.warning;
+      if (rmr != null && cr < rmr!) return colors.warning;
       if (cr < 200) return colors.success;
       return colors.success;
     }
 
     String zoneLabel() {
-      if (cr < liqRatio + 10) return 'CRITICAL — Near Liquidation';
-      if (cr < mcr) return 'DANGER — Below MCR';
-      if (cr < rmr) return 'CAUTION — Below RMR';
+      if (liqRatio != null && cr < liqRatio! + 10) return 'CRITICAL — Near Liquidation';
+      if (mcr != null && cr < mcr!) return 'DANGER — Below MCR';
+      if (rmr != null && cr < rmr!) return 'CAUTION — Below RMR';
       if (cr < 200) return 'MODERATE — Safe';
       return 'HEALTHY — Well Collateralized';
     }
@@ -456,9 +456,12 @@ class _GaugeContent extends StatelessWidget {
           ),
         ),
         const Divider(height: 20),
-        _ThresholdRow('Liquidation (LR)', liqRatio, colors.error),
-        _ThresholdRow('Maintenance (MCR)', mcr, colors.warning),
-        _ThresholdRow('Redemption (RMR)', rmr, colors.warning),
+        if (liqRatio != null) _ThresholdRow('Liquidation (LR)', liqRatio!, colors.error)
+        else _ThresholdRowNA('Liquidation (LR)', colors.textMuted),
+        if (mcr != null) _ThresholdRow('Maintenance (MCR)', mcr!, colors.warning)
+        else _ThresholdRowNA('Maintenance (MCR)', colors.textMuted),
+        if (rmr != null) _ThresholdRow('Redemption (RMR)', rmr!, colors.warning)
+        else _ThresholdRowNA('Redemption (RMR)', colors.textMuted),
       ],
     );
   }
@@ -507,18 +510,20 @@ class _ScenarioTable extends StatelessWidget {
             cr = (collateral / simPrice / minted) * 100;
           }
           final liq = asset.liquidationRatio;
-          final status = cr < liq
+          final mcr = asset.maintenanceRatio;
+          final rmr = asset.rmr;
+          final status = (liq != null && cr < liq)
               ? 'LIQUIDATED'
-              : cr < asset.maintenanceRatio
+              : (mcr != null && cr < mcr)
               ? 'Below MCR'
-              : cr < asset.rmr
+              : (rmr != null && cr < rmr)
               ? 'Below RMR'
               : 'Safe';
-          final statusColor = cr < liq
+          final statusColor = (liq != null && cr < liq)
               ? colors.error
-              : cr < asset.maintenanceRatio
+              : (mcr != null && cr < mcr)
               ? colors.warning
-              : cr < asset.rmr
+              : (rmr != null && cr < rmr)
               ? colors.warning
               : colors.success;
           return DataRow(
@@ -679,6 +684,27 @@ class _MetricRow extends StatelessWidget {
               fontWeight: FontWeight.w600,
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThresholdRowNA extends StatelessWidget {
+  final String label;
+  final Color color;
+  const _ThresholdRowNA(this.label, this.color);
+
+  @override
+  Widget build(BuildContext context) {
+    final styles = AppTextStyles.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: styles.bodySm.copyWith(color: color)),
+          Text('—', style: styles.monoSm.copyWith(color: color)),
         ],
       ),
     );

--- a/lib/views/insights/redemption/redeemable_over_rmrs_chart.dart
+++ b/lib/views/insights/redemption/redeemable_over_rmrs_chart.dart
@@ -71,7 +71,7 @@ class RedeemableOverRmrsChart extends StatelessWidget {
       }),
       builder: (data) {
         return PercentageAmountChart(
-          title: 'Redeemable over RMRs (${indigoAsset.rmr}%)',
+          title: 'Redeemable over RMRs${indigoAsset.rmr != null ? ' (${indigoAsset.rmr}%)' : ''}',
           currency: indigoAsset.asset,
           labels: [indigoAsset.asset],
           mintedSupply: data.cdps.map((e) => e.mintedAmount).sum,

--- a/lib/views/insights/stability_pool/stability_pool_analytics_card.dart
+++ b/lib/views/insights/stability_pool/stability_pool_analytics_card.dart
@@ -134,8 +134,10 @@ class _AnalyticsContent extends StatelessWidget {
         ),
         Divider(color: colors.border),
         infoRow(
-          'Unclaimed ADA',
-          '${numberAbbreviatedFormatter(totalUnclaimed, unclaimedAbbr)} ADA',
+          'Unclaimed Rewards',
+          totalUnclaimed > 0
+              ? '${numberAbbreviatedFormatter(totalUnclaimed, unclaimedAbbr)} ADA'
+              : '— (V3)',
           valueColor: colors.primary,
         ),
 

--- a/lib/views/insights/stability_pool/stability_pool_analytics_card.dart
+++ b/lib/views/insights/stability_pool/stability_pool_analytics_card.dart
@@ -79,15 +79,7 @@ class _AnalyticsContent extends StatelessWidget {
     final top10Sum = balances.take(10).fold(0.0, (s, b) => s + b);
     final top10Pct = totalSp > 0 ? (top10Sum / totalSp) * 100 : 0.0;
 
-    double totalUnclaimed = 0;
-    for (final a in accounts) {
-      try {
-        totalUnclaimed += pool.getAccountUnclaimedRewards(a);
-      } catch (_) {}
-    }
-
     final abbr = getAbbreviation(totalSp);
-    final unclaimedAbbr = getAbbreviation(totalUnclaimed);
 
     infoRow(String title, String value, {Color? valueColor}) =>
         Padding(
@@ -132,15 +124,6 @@ class _AnalyticsContent extends StatelessWidget {
           '${top10Pct.toStringAsFixed(1)}%',
           valueColor: top10Pct > 50 ? colors.warning : colors.success,
         ),
-        Divider(color: colors.border),
-        infoRow(
-          'Unclaimed Rewards',
-          totalUnclaimed > 0
-              ? '${numberAbbreviatedFormatter(totalUnclaimed, unclaimedAbbr)} ADA'
-              : '— (V3)',
-          valueColor: colors.primary,
-        ),
-
         if (balances.isNotEmpty) ...[
           const SizedBox(height: 14),
           Text(

--- a/lib/views/insights/stability_pool/stability_pool_insights.dart
+++ b/lib/views/insights/stability_pool/stability_pool_insights.dart
@@ -117,7 +117,9 @@ class _SpTabViewState extends State<_SpTabView> {
     if (simulatedPrice.isInfinite) return false;
     final collateralInAsset = c.collateralAmount / simulatedPrice;
     final cr = collateralInAsset / c.mintedAmount;
-    return cr < asset.liquidationRatio / 100;
+    final lr = asset.liquidationRatio;
+    if (lr == null) return false;
+    return cr < lr / 100;
   }).toList();
 
   @override
@@ -469,7 +471,8 @@ class _HistoricalLiqStatsStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
-    final prices = liquidations.map((l) => l.oraclePrice).toList()..sort();
+    final prices = liquidations.map((l) => l.oraclePrice).whereType<double>().toList()..sort();
+    if (prices.isEmpty) return const SizedBox.shrink();
     final minPrice = prices.first;
     final maxPrice = prices.last;
     final avgPrice = prices.reduce((a, b) => a + b) / prices.length;

--- a/lib/views/insights/stability_pool/stability_pool_insights.dart
+++ b/lib/views/insights/stability_pool/stability_pool_insights.dart
@@ -25,7 +25,7 @@ import 'package:indigo_insights/widgets/ii_top_bar.dart';
 
 typedef _SpTabData = ({
   List<Cdp> cdps,
-  AssetPrice price,
+  List<AssetPrice> prices, // all (asset, collateral) price rows for this iAsset
   StabilityPool? pool,
   List<Liquidation> liquidations,
 });
@@ -71,21 +71,15 @@ class _SpTabContent extends StatelessWidget {
         final cdps = (results[0] as List<Cdp>)
             .where((c) => c.asset == asset.asset)
             .toList();
-        final prices = results[1] as List<AssetPrice>;
-        final price =
-            prices.firstWhereOrNull((p) => p.asset == asset.asset) ??
-            AssetPrice(asset: asset.asset, price: 1.0);
+        final prices = (results[1] as List<AssetPrice>)
+            .where((p) => p.asset == asset.asset)
+            .toList();
         final pools = results[2] as List<StabilityPool>;
         final pool = pools.firstWhereOrNull((p) => p.asset == asset.asset);
         final liquidations = (results[3] as List<Liquidation>)
             .where((l) => l.asset == asset.asset)
             .toList();
-        return (
-          cdps: cdps,
-          price: price,
-          pool: pool,
-          liquidations: liquidations,
-        );
+        return (cdps: cdps, prices: prices, pool: pool, liquidations: liquidations);
       },
       builder: (data) => _SpTabView(asset: asset, data: data),
       errorBuilder: (error, retry) => Center(child: Text(error.toString())),
@@ -108,42 +102,57 @@ class _SpTabViewState extends State<_SpTabView> {
   IndigoAsset get asset => widget.asset;
   _SpTabData get data => widget.data;
 
-  double get simulatedPrice => _dropPercent >= 100
-      ? double.infinity
-      : data.price.price / (1 - _dropPercent / 100);
+  /// Simulated price per collateral: same % drop applied to every collateral type.
+  Map<String, double> get _simPrices {
+    if (_dropPercent >= 100) return {};
+    final factor = 1 - _dropPercent / 100;
+    return {for (final p in data.prices) p.collateralAsset: p.price / factor};
+  }
 
-  List<Cdp> get liquidatableCdps => data.cdps.where((c) {
-    if (c.mintedAmount <= 0) return false;
-    if (simulatedPrice.isInfinite) return false;
-    final collateralInAsset = c.collateralAmount / simulatedPrice;
-    final cr = collateralInAsset / c.mintedAmount;
-    final lr = asset.liquidationRatio;
-    if (lr == null) return false;
-    return cr < lr / 100;
-  }).toList();
+  List<Cdp> _liquidatable(Map<String, double> simPrices) =>
+      data.cdps.where((c) {
+        if (c.mintedAmount <= 0) return false;
+        final sp = simPrices[c.collateralAsset];
+        if (sp == null || sp.isInfinite || sp <= 0) return false;
+        final cr = (c.collateralAmount / sp) / c.mintedAmount;
+        return cr < asset.getLiquidationRatio(c.collateralAsset) / 100;
+      }).toList();
+
+  /// Collateral at risk grouped by collateral type (98% absorbed by SP per protocol).
+  Map<String, double> _collateralByType(List<Cdp> liqs) {
+    final map = <String, double>{};
+    for (final c in liqs) {
+      map[c.collateralAsset] =
+          (map[c.collateralAsset] ?? 0) + c.collateralAmount * 0.98;
+    }
+    return map;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final liqs = liquidatableCdps;
+    final simPrices = _simPrices;
+    final liqs = _liquidatable(simPrices);
     final totalMintedAtRisk = liqs.fold(0.0, (s, c) => s + c.mintedAmount);
-    final totalCollateralAtRisk = liqs.fold(
-      0.0,
-      (s, c) => s + c.collateralAmount * 0.98,
-    );
+    final collateralByType = _collateralByType(liqs);
     final spBalance = data.pool?.totalAmount ?? 0.0;
-    final spCanAbsorb = spBalance >= totalMintedAtRisk;
+    // Fraction of liquidatable debt the SP can absorb (0.0–1.0).
+    final absorptionFraction = totalMintedAtRisk > 0
+        ? (spBalance / totalMintedAtRisk).clamp(0.0, 1.0)
+        : 0.0;
+    final spCanAbsorb = absorptionFraction >= 1.0;
     final remainingSp = spBalance - totalMintedAtRisk;
-    final remainingCollateral =
-        (totalCollateralAtRisk -
-                (spCanAbsorb
-                    ? totalCollateralAtRisk
-                    : spBalance / totalMintedAtRisk * totalCollateralAtRisk))
-            .clamp(0.0, double.infinity);
+    // Split collateral absorbed/remaining proportionally across all collateral types.
+    final collateralAbsorbed = {
+      for (final e in collateralByType.entries)
+        e.key: e.value * absorptionFraction,
+    };
+    final collateralRemaining = {
+      for (final e in collateralByType.entries)
+        e.key: e.value * (1 - absorptionFraction),
+    };
 
     final mintAbbr = getAbbreviation(totalMintedAtRisk);
-    final collAbbr = getAbbreviation(totalCollateralAtRisk);
     final premiumPct = (9.1).toStringAsFixed(1);
-
     final isDesktop = MediaQuery.of(context).size.width >= 700;
 
     return SingleChildScrollView(
@@ -151,13 +160,11 @@ class _SpTabViewState extends State<_SpTabView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // ── Historical liquidation price stats ───────────────────────────
           if (data.liquidations.isNotEmpty) ...[
             _HistoricalLiqStatsStrip(liquidations: data.liquidations),
             const SizedBox(height: 16),
           ],
 
-          // ── Existing analytics row ────────────────────────────────────────
           if (isDesktop)
             SizedBox(
               height: 380,
@@ -196,36 +203,32 @@ class _SpTabViewState extends State<_SpTabView> {
 
           const SizedBox(height: 24),
 
-          // ── Liquidation Scenario Simulator ────────────────────────────────
           _ScenarioSimulatorSection(
             asset: asset,
             dropPercent: _dropPercent,
             onDropChanged: (v) => setState(() => _dropPercent = v),
+            simPrices: simPrices,
             liqs: liqs,
             totalMintedAtRisk: totalMintedAtRisk,
-            totalCollateralAtRisk: totalCollateralAtRisk,
+            collateralAbsorbed: collateralAbsorbed,
+            collateralRemaining: collateralRemaining,
             remainingSp: remainingSp,
             spCanAbsorb: spCanAbsorb,
             mintAbbr: mintAbbr,
-            collAbbr: collAbbr,
             premiumPct: premiumPct,
-            remainingCollateral: remainingCollateral,
-            simulatedPrice: simulatedPrice,
             isDesktop: isDesktop,
           ),
 
-          // ── Top Endangered CDPs ───────────────────────────────────────────
           if (liqs.isNotEmpty) ...[
             const SizedBox(height: 16),
             _TopEndangeredList(
-              cdps:
-                  (liqs..sort(
-                        (a, b) => b.mintedAmount.compareTo(a.mintedAmount),
-                      ))
-                      .take(5)
-                      .toList(),
+              cdps: (liqs..sort(
+                    (a, b) => b.mintedAmount.compareTo(a.mintedAmount),
+                  ))
+                  .take(5)
+                  .toList(),
               asset: asset,
-              simulatedPrice: simulatedPrice,
+              simPrices: simPrices,
             ),
           ],
         ],
@@ -234,45 +237,105 @@ class _SpTabViewState extends State<_SpTabView> {
   }
 }
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Renders a multi-collateral amount map as "2.40K ADA\n1.80K NIGHT".
+/// Returns "0.00" when empty.
+String _collateralMapLabel(Map<String, double> amounts) {
+  final parts = amounts.entries
+      .where((e) => e.value > 0.0005)
+      .map((e) {
+        final abbr = getAbbreviation(e.value);
+        return '${numberAbbreviatedFormatter(e.value, abbr)} ${collateralLabel(e.key)}';
+      })
+      .toList();
+  return parts.isEmpty ? '0.00' : parts.join('\n');
+}
+
 // ─── Scenario Simulator Section ───────────────────────────────────────────────
 
 class _ScenarioSimulatorSection extends StatelessWidget {
   final IndigoAsset asset;
   final double dropPercent;
   final ValueChanged<double> onDropChanged;
+  final Map<String, double> simPrices;
   final List<Cdp> liqs;
   final double totalMintedAtRisk;
-  final double totalCollateralAtRisk;
+  final Map<String, double> collateralAbsorbed;
+  final Map<String, double> collateralRemaining;
   final double remainingSp;
   final bool spCanAbsorb;
   final NumberAbbreviation? mintAbbr;
-  final NumberAbbreviation? collAbbr;
   final String premiumPct;
-  final double remainingCollateral;
-  final double simulatedPrice;
   final bool isDesktop;
 
   const _ScenarioSimulatorSection({
     required this.asset,
     required this.dropPercent,
     required this.onDropChanged,
+    required this.simPrices,
     required this.liqs,
     required this.totalMintedAtRisk,
-    required this.totalCollateralAtRisk,
+    required this.collateralAbsorbed,
+    required this.collateralRemaining,
     required this.remainingSp,
     required this.spCanAbsorb,
     required this.mintAbbr,
-    required this.collAbbr,
     required this.premiumPct,
-    required this.remainingCollateral,
-    required this.simulatedPrice,
     required this.isDesktop,
   });
+
+  /// "33.1760 ADA · 26.4009 NIGHT" style label for the slider.
+  String get _priceLabel {
+    final parts = simPrices.entries
+        .map((e) => '${numberFormatter(e.value, 4)} ${collateralLabel(e.key)}')
+        .toList();
+    return parts.isEmpty ? '' : '(${parts.join(' · ')})';
+  }
 
   @override
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
+    final hasRemaining = collateralRemaining.values.any((v) => v > 0.0005);
+
+    final panels = [
+      _CascadePanel(
+        label: 'Liquidatable CDPs',
+        value: '${liqs.length}',
+        sub: '${numberAbbreviatedFormatter(totalMintedAtRisk, mintAbbr)} ${asset.asset} at risk',
+        color: liqs.isEmpty ? colors.success : colors.error,
+        icon: Icons.warning_amber_outlined,
+      ),
+      _CascadePanel(
+        label: 'Collateral Absorbed',
+        value: _collateralMapLabel(collateralAbsorbed),
+        sub: 'by Stability Pool',
+        color: colors.warning,
+        icon: Icons.account_balance,
+      ),
+      _CascadePanel(
+        label: 'Remaining SP After',
+        value: remainingSp >= 0
+            ? '${numberAbbreviatedFormatter(remainingSp, getAbbreviation(remainingSp))} ${asset.asset}'
+            : 'SP EMPTY',
+        sub: remainingSp >= 0
+            ? 'buffer remaining'
+            : 'Add funds to earn $premiumPct% premium per liquidation',
+        color: remainingSp >= 0 ? colors.success : colors.warning,
+        icon: remainingSp >= 0
+            ? Icons.check_circle_outline
+            : Icons.savings_outlined,
+      ),
+      _CascadePanel(
+        label: 'Remaining Collateral to Absorb',
+        value:
+            hasRemaining ? _collateralMapLabel(collateralRemaining) : 'Fully Covered',
+        sub: hasRemaining ? 'not yet absorbed by SP' : 'SP covers all collateral',
+        color: hasRemaining ? colors.error : colors.success,
+        icon: Icons.layers_outlined,
+      ),
+    ];
 
     return IICard(
       padding: const EdgeInsets.all(16),
@@ -281,17 +344,15 @@ class _ScenarioSimulatorSection extends StatelessWidget {
         children: [
           Text('Liquidation Scenario Simulator', style: styles.cardTitle),
           const SizedBox(height: 12),
-          // Slider
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                'ADA Price Drop',
+                'Collateral Price Drop',
                 style: styles.bodySm.copyWith(color: colors.textSecondary),
               ),
               Text(
-                '-${dropPercent.toStringAsFixed(0)}%  '
-                '(${numberFormatter(simulatedPrice.isInfinite ? 0 : simulatedPrice, 4)} ADA)',
+                '-${dropPercent.toStringAsFixed(0)}%  $_priceLabel',
                 style: styles.bodySm.copyWith(
                   color: dropPercent > 30 ? colors.error : colors.warning,
                   fontWeight: FontWeight.bold,
@@ -308,92 +369,21 @@ class _ScenarioSimulatorSection extends StatelessWidget {
             onChanged: onDropChanged,
           ),
           const SizedBox(height: 12),
-          // Cascade panels — Row on desktop, full-width Column on mobile
           if (isDesktop)
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(child: _CascadePanel(
-                  label: 'Liquidatable CDPs',
-                  value: '${liqs.length}',
-                  sub: '${numberAbbreviatedFormatter(totalMintedAtRisk, mintAbbr)} ${asset.asset} at risk',
-                  color: liqs.isEmpty ? colors.success : colors.error,
-                  icon: Icons.warning_amber_outlined,
-                )),
-                const SizedBox(width: 10),
-                Expanded(child: _CascadePanel(
-                  label: 'Collateral Absorbed',
-                  value: '${numberAbbreviatedFormatter(totalCollateralAtRisk, collAbbr)} ADA',
-                  sub: 'by Stability Pool',
-                  color: colors.warning,
-                  icon: Icons.account_balance,
-                )),
-                const SizedBox(width: 10),
-                Expanded(child: _CascadePanel(
-                  label: 'Remaining SP After',
-                  value: remainingSp >= 0
-                      ? '${numberAbbreviatedFormatter(remainingSp, getAbbreviation(remainingSp))} ${asset.asset}'
-                      : 'SP EMPTY',
-                  sub: remainingSp >= 0
-                      ? 'buffer remaining'
-                      : 'Add funds to earn $premiumPct% ADA premium per liquidation',
-                  color: remainingSp >= 0 ? colors.success : colors.warning,
-                  icon: remainingSp >= 0 ? Icons.check_circle_outline : Icons.savings_outlined,
-                )),
-                const SizedBox(width: 10),
-                Expanded(child: _CascadePanel(
-                  label: 'Remaining Collateral to Absorb',
-                  value: remainingCollateral > 0
-                      ? '${numberAbbreviatedFormatter(remainingCollateral, getAbbreviation(remainingCollateral))} ADA'
-                      : 'Fully Covered',
-                  sub: remainingCollateral > 0 ? 'not yet absorbed by SP' : 'SP covers all collateral',
-                  color: remainingCollateral > 0 ? colors.error : colors.success,
-                  icon: Icons.layers_outlined,
-                )),
-              ],
+              children: panels
+                  .expand((p) => [Expanded(child: p), const SizedBox(width: 10)])
+                  .toList()
+                ..removeLast(),
             )
           else
             Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _CascadePanel(
-                  label: 'Liquidatable CDPs',
-                  value: '${liqs.length}',
-                  sub: '${numberAbbreviatedFormatter(totalMintedAtRisk, mintAbbr)} ${asset.asset} at risk',
-                  color: liqs.isEmpty ? colors.success : colors.error,
-                  icon: Icons.warning_amber_outlined,
-                ),
-                const SizedBox(height: 10),
-                _CascadePanel(
-                  label: 'Collateral Absorbed',
-                  value: '${numberAbbreviatedFormatter(totalCollateralAtRisk, collAbbr)} ADA',
-                  sub: 'by Stability Pool',
-                  color: colors.warning,
-                  icon: Icons.account_balance,
-                ),
-                const SizedBox(height: 10),
-                _CascadePanel(
-                  label: 'Remaining SP After',
-                  value: remainingSp >= 0
-                      ? '${numberAbbreviatedFormatter(remainingSp, getAbbreviation(remainingSp))} ${asset.asset}'
-                      : 'SP EMPTY',
-                  sub: remainingSp >= 0
-                      ? 'buffer remaining'
-                      : 'Add funds to earn $premiumPct% ADA premium per liquidation',
-                  color: remainingSp >= 0 ? colors.success : colors.warning,
-                  icon: remainingSp >= 0 ? Icons.check_circle_outline : Icons.savings_outlined,
-                ),
-                const SizedBox(height: 10),
-                _CascadePanel(
-                  label: 'Remaining Collateral to Absorb',
-                  value: remainingCollateral > 0
-                      ? '${numberAbbreviatedFormatter(remainingCollateral, getAbbreviation(remainingCollateral))} ADA'
-                      : 'Fully Covered',
-                  sub: remainingCollateral > 0 ? 'not yet absorbed by SP' : 'SP covers all collateral',
-                  color: remainingCollateral > 0 ? colors.error : colors.success,
-                  icon: Icons.layers_outlined,
-                ),
-              ],
+              children: panels
+                  .expand((p) => [p, const SizedBox(height: 10)])
+                  .toList()
+                ..removeLast(),
             ),
         ],
       ),
@@ -437,9 +427,7 @@ class _CascadePanel extends StatelessWidget {
               Expanded(
                 child: Text(
                   label,
-                  style: styles.sectionLabel.copyWith(
-                    color: colors.textSecondary,
-                  ),
+                  style: styles.sectionLabel.copyWith(color: colors.textSecondary),
                 ),
               ),
             ],
@@ -471,7 +459,9 @@ class _HistoricalLiqStatsStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
-    final prices = liquidations.map((l) => l.oraclePrice).whereType<double>().toList()..sort();
+    final prices =
+        liquidations.map((l) => l.oraclePrice).whereType<double>().toList()
+          ..sort();
     if (prices.isEmpty) return const SizedBox.shrink();
     final minPrice = prices.first;
     final maxPrice = prices.last;
@@ -521,12 +511,12 @@ class _HistoricalLiqStatsStrip extends StatelessWidget {
 class _TopEndangeredList extends StatefulWidget {
   final List<Cdp> cdps;
   final IndigoAsset asset;
-  final double simulatedPrice;
+  final Map<String, double> simPrices;
 
   const _TopEndangeredList({
     required this.cdps,
     required this.asset,
-    required this.simulatedPrice,
+    required this.simPrices,
   });
 
   @override
@@ -556,14 +546,15 @@ class _TopEndangeredListState extends State<_TopEndangeredList> {
           Text('Top Endangered CDPs', style: styles.cardTitle),
           const SizedBox(height: 8),
           ...widget.cdps.mapIndexed((i, cdp) {
+            final simPrice = widget.simPrices[cdp.collateralAsset] ?? 0.0;
             final collateralInAsset =
-                widget.simulatedPrice > 0 && widget.simulatedPrice.isFinite
-                ? cdp.collateralAmount / widget.simulatedPrice
-                : 0.0;
+                simPrice > 0 ? cdp.collateralAmount / simPrice : 0.0;
             final cr = cdp.mintedAmount > 0
                 ? (collateralInAsset / cdp.mintedAmount) * 100
                 : 0.0;
             final isCopied = _copiedOwner == cdp.owner;
+            final collLabel = collateralLabel(cdp.collateralAsset);
+
             return Padding(
               padding: const EdgeInsets.symmetric(vertical: 6),
               child: Row(
@@ -587,7 +578,7 @@ class _TopEndangeredListState extends State<_TopEndangeredList> {
                           overflow: TextOverflow.ellipsis,
                         ),
                         Text(
-                          '${numberFormatter(cdp.collateralAmount, 0)} ADA / '
+                          '${numberFormatter(cdp.collateralAmount, 0)} $collLabel / '
                           '${numberFormatter(cdp.mintedAmount, 2)} ${widget.asset.asset}',
                           style: styles.sectionLabel.copyWith(
                             color: colors.textSecondary,

--- a/lib/views/insights/stability_pool/stability_pool_solvency_chart.dart
+++ b/lib/views/insights/stability_pool/stability_pool_solvency_chart.dart
@@ -16,6 +16,9 @@ class StabilityPoolSolvencyChart extends StatelessWidget {
     return AsyncBuilder(
       fetcher: () => sl<SolvencyRepository>().getForAsset(indigoAsset),
       builder: (stabilityPoolSolvencyData) {
+        if (stabilityPoolSolvencyData.isEmpty) {
+          return const Center(child: Text('No stability pool data available.'));
+        }
         return AmountPercentageChart(
           currency: indigoAsset.asset,
           labels: const ['Balance'],

--- a/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_card.dart
+++ b/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_card.dart
@@ -19,9 +19,9 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
 
   final String asset;
   final double interestRate;
-  final double redemptionMarginRatio;
-  final double maintenanceRatio;
-  final double liquidationRatio;
+  final double? redemptionMarginRatio;
+  final double? maintenanceRatio;
+  final double? liquidationRatio;
   final double assetPrice;
   final double debtMintingFee;
   final double collateralRatio;
@@ -42,15 +42,17 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double amount) => Text(
-      '${numberFormatter(amount, 2)}%',
+    calculatedAmount(double? amount) => Text(
+      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
       style: styles.monoSm.copyWith(color: colors.textPrimary),
     );
 
     final cr = collateralRatio / 100;
     final doubleLeverage = 1 + (1 + 1 / cr) / cr;
     final liquidationLoss = -(1 - (1 / cr) / cr) * 100;
-    final priceDropToLiquidation = (1 - (liquidationRatio / collateralRatio)) * 100;
+    final priceDropToLiquidation = liquidationRatio != null
+        ? (1 - (liquidationRatio! / collateralRatio)) * 100
+        : null;
 
     return Card(
       child: Padding(
@@ -77,7 +79,9 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
             informationRow(
               'Liquidation Price Drop',
               Text(
-                '-${numberFormatter(priceDropToLiquidation, 2)}%',
+                priceDropToLiquidation != null
+                    ? '-${numberFormatter(priceDropToLiquidation, 2)}%'
+                    : '—',
                 style: styles.monoSm.copyWith(color: colors.error, fontWeight: FontWeight.bold),
               ),
             ),

--- a/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_card.dart
+++ b/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_card.dart
@@ -8,20 +8,16 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
   const AdaDoubleLeverageAboveMrCard({
     super.key,
     required this.asset,
+    required this.collateralAsset,
     required this.interestRate,
-    required this.redemptionMarginRatio,
-    required this.maintenanceRatio,
-    required this.liquidationRatio,
     required this.assetPrice,
     required this.debtMintingFee,
     required this.collateralRatio,
   });
 
   final String asset;
+  final String collateralAsset;
   final double interestRate;
-  final double? redemptionMarginRatio;
-  final double? maintenanceRatio;
-  final double? liquidationRatio;
   final double assetPrice;
   final double debtMintingFee;
   final double collateralRatio;
@@ -30,6 +26,7 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
+    final collateral = collateralLabel(collateralAsset);
 
     informationRow(String label, Widget info) => Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
@@ -42,17 +39,17 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double? amount) => Text(
-      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
-      style: styles.monoSm.copyWith(color: colors.textPrimary),
+    valueText(String v, {Color? color}) => Text(
+      v,
+      style: styles.monoSm.copyWith(
+        color: color ?? colors.textPrimary,
+        fontWeight: FontWeight.w600,
+      ),
     );
 
     final cr = collateralRatio / 100;
     final doubleLeverage = 1 + (1 + 1 / cr) / cr;
     final liquidationLoss = -(1 - (1 / cr) / cr) * 100;
-    final priceDropToLiquidation = liquidationRatio != null
-        ? (1 - (liquidationRatio! / collateralRatio)) * 100
-        : null;
 
     return Card(
       child: Padding(
@@ -63,10 +60,10 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(asset, style: styles.cardTitle),
+                Text('$asset ($collateral Collateral)', style: styles.cardTitle),
                 Tooltip(
                   message:
-                      'This is the maximum theoretical double\nleverage achievable based on the\nMaintenance Ratio.',
+                      'Maximum theoretical double\nleverage based on the Maintenance Ratio.',
                   child: AnimatedGradientText(
                     '${numberFormatter(doubleLeverage, 2)}x',
                     gradientColors: [colors.success, colors.error],
@@ -77,27 +74,23 @@ class AdaDoubleLeverageAboveMrCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             informationRow(
-              'Liquidation Price Drop',
-              Text(
-                priceDropToLiquidation != null
-                    ? '-${numberFormatter(priceDropToLiquidation, 2)}%'
-                    : '—',
-                style: styles.monoSm.copyWith(color: colors.error, fontWeight: FontWeight.bold),
-              ),
-            ),
-            informationRow(
               'Liquidation Loss',
-              Text(
-                '${numberFormatter(liquidationLoss, 2)}%',
-                style: styles.monoSm.copyWith(color: colors.error, fontWeight: FontWeight.bold),
-              ),
+              valueText('${numberFormatter(liquidationLoss, 2)}%', color: colors.error),
             ),
             Divider(color: colors.border, height: 16),
-            informationRow('Interest Rate', calculatedAmount(interestRate)),
-            informationRow('Redemption Margin Ratio', calculatedAmount(redemptionMarginRatio)),
-            informationRow('Maintenance Ratio', calculatedAmount(maintenanceRatio)),
-            informationRow('Liquidation Ratio', calculatedAmount(liquidationRatio)),
-            informationRow('Minting Fee', calculatedAmount(debtMintingFee)),
+            informationRow('Collateral', valueText(collateral)),
+            informationRow(
+              'Price',
+              valueText('${numberFormatter(assetPrice, 4)} $collateral'),
+            ),
+            informationRow(
+              'Interest Rate',
+              valueText('${numberFormatter(interestRate, 2)}%'),
+            ),
+            informationRow(
+              'Minting Fee',
+              valueText('${numberFormatter(debtMintingFee, 2)}%'),
+            ),
           ],
         ),
       ),

--- a/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_content.dart
+++ b/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_content.dart
@@ -27,7 +27,7 @@ class _AdaDoubleLeverageAboveMrContentState
     return AsyncBuilder(
       fetcher: () => sl<StrategyRepository>().getLeverageData(),
       builder: (leveragesData) {
-        final minCr = leveragesData.map((e) => e.mcr).min;
+        final minCr = leveragesData.map((e) => e.mcr).whereType<double>().minOrNull ?? 150.0;
         const maxCr = 500.0;
         _collateralRatio ??= minCr;
 
@@ -79,9 +79,9 @@ class _AdaDoubleLeverageAboveMrContentState
                             liquidationRatio: data.liquidationRatio,
                             assetPrice: data.assetPrice,
                             debtMintingFee: data.debtMintingFee,
-                            collateralRatio: (_collateralRatio ?? minCr) > data.mcr
+                            collateralRatio: (_collateralRatio ?? minCr) > (data.mcr ?? minCr)
                                 ? (_collateralRatio ?? minCr)
-                                : data.mcr,
+                                : (data.mcr ?? minCr),
                           )
                               .animate()
                               .slideX(duration: 300.ms, curve: Curves.easeInOut)

--- a/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_content.dart
+++ b/lib/views/insights/strategy/ada_double_leverage_above_mr/ada_double_leverage_above_mr_content.dart
@@ -73,15 +73,11 @@ class _AdaDoubleLeverageAboveMrContentState
                           width: itemWidth,
                           child: AdaDoubleLeverageAboveMrCard(
                             asset: data.asset,
+                            collateralAsset: data.collateralAsset,
                             interestRate: data.interestRate,
-                            redemptionMarginRatio: data.rmr,
-                            maintenanceRatio: data.mcr,
-                            liquidationRatio: data.liquidationRatio,
                             assetPrice: data.assetPrice,
                             debtMintingFee: data.debtMintingFee,
-                            collateralRatio: (_collateralRatio ?? minCr) > (data.mcr ?? minCr)
-                                ? (_collateralRatio ?? minCr)
-                                : (data.mcr ?? minCr),
+                            collateralRatio: _collateralRatio ?? minCr,
                           )
                               .animate()
                               .slideX(duration: 300.ms, curve: Curves.easeInOut)

--- a/lib/views/insights/strategy/ada_farming_stability_pool/ada_farming_stability_pool_card.dart
+++ b/lib/views/insights/strategy/ada_farming_stability_pool/ada_farming_stability_pool_card.dart
@@ -8,28 +8,27 @@ class AdaFarmingStabilityPoolCard extends StatelessWidget {
   const AdaFarmingStabilityPoolCard({
     super.key,
     required this.title,
+    required this.collateralAsset,
     required this.strategyYield,
     required this.poolYield,
     required this.interestRate,
-    required this.redemptionMarginRatio,
-    required this.maintenanceRatio,
-    required this.liquidationRatio,
+    required this.assetPrice,
     required this.debtMintingFee,
   });
 
   final String title;
+  final String collateralAsset;
   final double strategyYield;
   final double poolYield;
   final double interestRate;
-  final double? redemptionMarginRatio;
-  final double? maintenanceRatio;
-  final double? liquidationRatio;
+  final double assetPrice;
   final double debtMintingFee;
 
   @override
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
+    final collateral = collateralLabel(collateralAsset);
 
     informationRow(String label, Widget info) => Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
@@ -42,9 +41,12 @@ class AdaFarmingStabilityPoolCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double? amount) => Text(
-      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
-      style: styles.monoSm.copyWith(color: colors.textPrimary),
+    valueText(String v, {Color? color, FontWeight? weight}) => Text(
+      v,
+      style: styles.monoSm.copyWith(
+        color: color ?? colors.textPrimary,
+        fontWeight: weight ?? FontWeight.w600,
+      ),
     );
 
     return Card(
@@ -56,15 +58,12 @@ class AdaFarmingStabilityPoolCard extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text('$title SP', style: styles.cardTitle),
+                Text('$title SP ($collateral Collateral)', style: styles.cardTitle),
                 AnimatedGradientText(
                   '${numberFormatter(strategyYield, 2)}%',
                   gradientColors: strategyYield > 0
                       ? [const Color(0xFFa500e1), const Color(0xFF3f83f8)]
-                      : [
-                          const Color(0xFFa500e1),
-                          colors.error,
-                        ],
+                      : [const Color(0xFFa500e1), colors.error],
                   style: styles.kpiValue.copyWith(fontSize: 18),
                 ),
               ],
@@ -72,29 +71,22 @@ class AdaFarmingStabilityPoolCard extends StatelessWidget {
             const SizedBox(height: 12),
             informationRow(
               'Stability Pool APR',
-              Text(
-                '${numberFormatter(poolYield, 2)}%',
-                style: styles.monoSm.copyWith(
-                  color: colors.success,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              valueText('${numberFormatter(poolYield, 2)}%', color: colors.success),
             ),
             informationRow(
               'CDP Interest Rate',
-              Text(
-                '${numberFormatter(interestRate, 2)}%',
-                style: styles.monoSm.copyWith(
-                  color: colors.warning,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              valueText('${numberFormatter(interestRate, 2)}%', color: colors.warning),
             ),
             Divider(color: colors.border, height: 16),
-            informationRow('Redemption Margin Ratio', calculatedAmount(redemptionMarginRatio)),
-            informationRow('Maintenance Ratio', calculatedAmount(maintenanceRatio)),
-            informationRow('Liquidation Ratio', calculatedAmount(liquidationRatio)),
-            informationRow('Minting Fee', calculatedAmount(debtMintingFee)),
+            informationRow('Collateral', valueText(collateral)),
+            informationRow(
+              'Price',
+              valueText('${numberFormatter(assetPrice, 4)} $collateral'),
+            ),
+            informationRow(
+              'Minting Fee',
+              valueText('${numberFormatter(debtMintingFee, 2)}%'),
+            ),
           ],
         ),
       ),

--- a/lib/views/insights/strategy/ada_farming_stability_pool/ada_farming_stability_pool_card.dart
+++ b/lib/views/insights/strategy/ada_farming_stability_pool/ada_farming_stability_pool_card.dart
@@ -21,9 +21,9 @@ class AdaFarmingStabilityPoolCard extends StatelessWidget {
   final double strategyYield;
   final double poolYield;
   final double interestRate;
-  final double redemptionMarginRatio;
-  final double maintenanceRatio;
-  final double liquidationRatio;
+  final double? redemptionMarginRatio;
+  final double? maintenanceRatio;
+  final double? liquidationRatio;
   final double debtMintingFee;
 
   @override
@@ -42,8 +42,8 @@ class AdaFarmingStabilityPoolCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double amount) => Text(
-      '${numberFormatter(amount, 2)}%',
+    calculatedAmount(double? amount) => Text(
+      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
       style: styles.monoSm.copyWith(color: colors.textPrimary),
     );
 

--- a/lib/views/insights/strategy/ada_farming_stability_pool/ada_farming_stability_pool_content.dart
+++ b/lib/views/insights/strategy/ada_farming_stability_pool/ada_farming_stability_pool_content.dart
@@ -49,12 +49,11 @@ class StabilityPoolFarmingStrategyContent extends StatelessWidget {
                         width: itemWidth,
                         child: AdaFarmingStabilityPoolCard(
                           title: strategyData.title,
+                          collateralAsset: strategyData.collateralAsset,
                           strategyYield: strategyData.strategyYield,
                           poolYield: strategyData.poolYield,
                           interestRate: strategyData.interestRate,
-                          redemptionMarginRatio: strategyData.rmr,
-                          maintenanceRatio: strategyData.mcr,
-                          liquidationRatio: strategyData.liquidationRatio,
+                          assetPrice: strategyData.assetPrice,
                           debtMintingFee: strategyData.debtMintingFee,
                         )
                             .animate()

--- a/lib/views/insights/strategy/ada_farming_stable_pool/ada_farming_stable_pool_card.dart
+++ b/lib/views/insights/strategy/ada_farming_stable_pool/ada_farming_stable_pool_card.dart
@@ -12,9 +12,6 @@ class AdaFarmingStablePoolCard extends StatelessWidget {
     required this.tradingFeesApr,
     required this.farmingApr,
     required this.interestRate,
-    required this.redemptionMarginRatio,
-    required this.maintenanceRatio,
-    required this.liquidationRatio,
     required this.debtMintingFee,
   });
 
@@ -23,9 +20,6 @@ class AdaFarmingStablePoolCard extends StatelessWidget {
   final double tradingFeesApr;
   final double farmingApr;
   final double interestRate;
-  final double? redemptionMarginRatio;
-  final double? maintenanceRatio;
-  final double? liquidationRatio;
   final double debtMintingFee;
 
   @override
@@ -42,11 +36,6 @@ class AdaFarmingStablePoolCard extends StatelessWidget {
           info,
         ],
       ),
-    );
-
-    calculatedAmount(double? amount) => Text(
-      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
-      style: styles.monoSm.copyWith(color: colors.textPrimary),
     );
 
     return Card(
@@ -91,10 +80,13 @@ class AdaFarmingStablePoolCard extends StatelessWidget {
               ),
             ),
             Divider(color: colors.border, height: 16),
-            informationRow('Redemption Margin Ratio', calculatedAmount(redemptionMarginRatio)),
-            informationRow('Maintenance Ratio', calculatedAmount(maintenanceRatio)),
-            informationRow('Liquidation Ratio', calculatedAmount(liquidationRatio)),
-            informationRow('Minting Fee', calculatedAmount(debtMintingFee)),
+            informationRow(
+              'Minting Fee',
+              Text(
+                '${numberFormatter(debtMintingFee, 2)}%',
+                style: styles.monoSm.copyWith(color: colors.textPrimary, fontWeight: FontWeight.w600),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/views/insights/strategy/ada_farming_stable_pool/ada_farming_stable_pool_card.dart
+++ b/lib/views/insights/strategy/ada_farming_stable_pool/ada_farming_stable_pool_card.dart
@@ -23,9 +23,9 @@ class AdaFarmingStablePoolCard extends StatelessWidget {
   final double tradingFeesApr;
   final double farmingApr;
   final double interestRate;
-  final double redemptionMarginRatio;
-  final double maintenanceRatio;
-  final double liquidationRatio;
+  final double? redemptionMarginRatio;
+  final double? maintenanceRatio;
+  final double? liquidationRatio;
   final double debtMintingFee;
 
   @override
@@ -44,8 +44,8 @@ class AdaFarmingStablePoolCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double amount) => Text(
-      '${numberFormatter(amount, 2)}%',
+    calculatedAmount(double? amount) => Text(
+      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
       style: styles.monoSm.copyWith(color: colors.textPrimary),
     );
 

--- a/lib/views/insights/strategy/ada_farming_stable_pool/ada_farming_stable_pool_content.dart
+++ b/lib/views/insights/strategy/ada_farming_stable_pool/ada_farming_stable_pool_content.dart
@@ -53,9 +53,6 @@ class StablePoolFarmingStrategyContent extends StatelessWidget {
                           tradingFeesApr: strategyData.tradingFeesApr,
                           farmingApr: strategyData.farmingApr,
                           interestRate: strategyData.interestRate,
-                          redemptionMarginRatio: strategyData.rmr,
-                          maintenanceRatio: strategyData.mcr,
-                          liquidationRatio: strategyData.liquidationRatio,
                           debtMintingFee: strategyData.debtMintingFee,
                         )
                             .animate()

--- a/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_card.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_card.dart
@@ -8,20 +8,16 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
   const AdaLeverageAboveMrCard({
     super.key,
     required this.asset,
+    required this.collateralAsset,
     required this.interestRate,
-    required this.redemptionMarginRatio,
-    required this.maintenanceRatio,
-    required this.liquidationRatio,
     required this.assetPrice,
     required this.debtMintingFee,
     required this.collateralRatio,
   });
 
   final String asset;
+  final String collateralAsset;
   final double interestRate;
-  final double? redemptionMarginRatio;
-  final double? maintenanceRatio;
-  final double? liquidationRatio;
   final double assetPrice;
   final double debtMintingFee;
   final double collateralRatio;
@@ -30,6 +26,7 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
+    final collateral = collateralLabel(collateralAsset);
 
     informationRow(String label, Widget info) => Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
@@ -42,17 +39,17 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double? amount) => Text(
-      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
-      style: styles.monoSm.copyWith(color: colors.textPrimary),
+    valueText(String v, {Color? color}) => Text(
+      v,
+      style: styles.monoSm.copyWith(
+        color: color ?? colors.textPrimary,
+        fontWeight: FontWeight.w600,
+      ),
     );
 
     final cr = collateralRatio / 100;
     final leverage = 1 + 1 / cr;
     final liquidationLoss = -(1 - 1 / cr) * 100;
-    final priceDropToLiquidation = liquidationRatio != null
-        ? (1 - (liquidationRatio! / collateralRatio)) * 100
-        : null;
 
     return Card(
       child: Padding(
@@ -63,10 +60,10 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(asset, style: styles.cardTitle),
+                Text('$asset ($collateral Collateral)', style: styles.cardTitle),
                 Tooltip(
                   message:
-                      'This is the maximum theoretical \nleverage achievable based on the \nMaintenance Ratio.',
+                      'Maximum theoretical leverage\nbased on the Maintenance Ratio.',
                   child: AnimatedGradientText(
                     '${numberFormatter(leverage, 2)}x',
                     gradientColors: [colors.warning, colors.success],
@@ -77,27 +74,23 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             informationRow(
-              'Liquidation Price Drop',
-              Text(
-                priceDropToLiquidation != null
-                    ? '-${numberFormatter(priceDropToLiquidation, 2)}%'
-                    : '—',
-                style: styles.monoSm.copyWith(color: colors.error, fontWeight: FontWeight.bold),
-              ),
-            ),
-            informationRow(
               'Liquidation Loss',
-              Text(
-                '${numberFormatter(liquidationLoss, 2)}%',
-                style: styles.monoSm.copyWith(color: colors.warning, fontWeight: FontWeight.bold),
-              ),
+              valueText('${numberFormatter(liquidationLoss, 2)}%', color: colors.warning),
             ),
             Divider(color: colors.border, height: 16),
-            informationRow('Interest Rate', calculatedAmount(interestRate)),
-            informationRow('Redemption Margin Ratio', calculatedAmount(redemptionMarginRatio)),
-            informationRow('Maintenance Ratio', calculatedAmount(maintenanceRatio)),
-            informationRow('Liquidation Ratio', calculatedAmount(liquidationRatio)),
-            informationRow('Minting Fee', calculatedAmount(debtMintingFee)),
+            informationRow('Collateral', valueText(collateral)),
+            informationRow(
+              'Price',
+              valueText('${numberFormatter(assetPrice, 4)} $collateral'),
+            ),
+            informationRow(
+              'Interest Rate',
+              valueText('${numberFormatter(interestRate, 2)}%'),
+            ),
+            informationRow(
+              'Minting Fee',
+              valueText('${numberFormatter(debtMintingFee, 2)}%'),
+            ),
           ],
         ),
       ),

--- a/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_card.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_card.dart
@@ -19,9 +19,9 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
 
   final String asset;
   final double interestRate;
-  final double redemptionMarginRatio;
-  final double maintenanceRatio;
-  final double liquidationRatio;
+  final double? redemptionMarginRatio;
+  final double? maintenanceRatio;
+  final double? liquidationRatio;
   final double assetPrice;
   final double debtMintingFee;
   final double collateralRatio;
@@ -42,15 +42,17 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double amount) => Text(
-      '${numberFormatter(amount, 2)}%',
+    calculatedAmount(double? amount) => Text(
+      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
       style: styles.monoSm.copyWith(color: colors.textPrimary),
     );
 
     final cr = collateralRatio / 100;
     final leverage = 1 + 1 / cr;
     final liquidationLoss = -(1 - 1 / cr) * 100;
-    final priceDropToLiquidation = (1 - (liquidationRatio / collateralRatio)) * 100;
+    final priceDropToLiquidation = liquidationRatio != null
+        ? (1 - (liquidationRatio! / collateralRatio)) * 100
+        : null;
 
     return Card(
       child: Padding(
@@ -77,7 +79,9 @@ class AdaLeverageAboveMrCard extends StatelessWidget {
             informationRow(
               'Liquidation Price Drop',
               Text(
-                '-${numberFormatter(priceDropToLiquidation, 2)}%',
+                priceDropToLiquidation != null
+                    ? '-${numberFormatter(priceDropToLiquidation, 2)}%'
+                    : '—',
                 style: styles.monoSm.copyWith(color: colors.error, fontWeight: FontWeight.bold),
               ),
             ),

--- a/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_content.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_content.dart
@@ -72,15 +72,11 @@ class _AdaLeverageAboveMrContentState extends State<AdaLeverageAboveMrContent> {
                           width: itemWidth,
                           child: AdaLeverageAboveMrCard(
                             asset: data.asset,
+                            collateralAsset: data.collateralAsset,
                             interestRate: data.interestRate,
-                            redemptionMarginRatio: data.rmr,
-                            maintenanceRatio: data.mcr,
-                            liquidationRatio: data.liquidationRatio,
                             assetPrice: data.assetPrice,
                             debtMintingFee: data.debtMintingFee,
-                            collateralRatio: (_collateralRatio ?? minCr) > (data.mcr ?? minCr)
-                                ? (_collateralRatio ?? minCr)
-                                : (data.mcr ?? minCr),
+                            collateralRatio: _collateralRatio ?? minCr,
                           )
                               .animate()
                               .slideX(duration: 300.ms, curve: Curves.easeInOut)

--- a/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_content.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_mr/ada_leverage_above_mr_content.dart
@@ -26,7 +26,7 @@ class _AdaLeverageAboveMrContentState extends State<AdaLeverageAboveMrContent> {
     return AsyncBuilder(
       fetcher: () => sl<StrategyRepository>().getLeverageData(),
       builder: (leveragesData) {
-        final minCr = leveragesData.map((e) => e.mcr).min;
+        final minCr = leveragesData.map((e) => e.mcr).whereType<double>().minOrNull ?? 150.0;
         const maxCr = 500.0;
         _collateralRatio ??= minCr;
 
@@ -78,9 +78,9 @@ class _AdaLeverageAboveMrContentState extends State<AdaLeverageAboveMrContent> {
                             liquidationRatio: data.liquidationRatio,
                             assetPrice: data.assetPrice,
                             debtMintingFee: data.debtMintingFee,
-                            collateralRatio: (_collateralRatio ?? minCr) > data.mcr
+                            collateralRatio: (_collateralRatio ?? minCr) > (data.mcr ?? minCr)
                                 ? (_collateralRatio ?? minCr)
-                                : data.mcr,
+                                : (data.mcr ?? minCr),
                           )
                               .animate()
                               .slideX(duration: 300.ms, curve: Curves.easeInOut)

--- a/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_card.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_card.dart
@@ -19,9 +19,9 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
 
   final String asset;
   final double interestRate;
-  final double redemptionMarginRatio;
-  final double maintenanceRatio;
-  final double liquidationRatio;
+  final double? redemptionMarginRatio;
+  final double? maintenanceRatio;
+  final double? liquidationRatio;
   final double assetPrice;
   final double debtMintingFee;
   final double collateralRatio;
@@ -42,15 +42,17 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double amount) => Text(
-      '${numberFormatter(amount, 2)}%',
+    calculatedAmount(double? amount) => Text(
+      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
       style: styles.monoSm.copyWith(color: colors.textPrimary),
     );
 
     final cr = collateralRatio / 100;
     final leverage = 1 + 1 / cr;
     final liquidationLoss = -(1 - 1 / cr) * 100;
-    final priceDropToLiquidation = (1 - (liquidationRatio / collateralRatio)) * 100;
+    final priceDropToLiquidation = liquidationRatio != null
+        ? (1 - (liquidationRatio! / collateralRatio)) * 100
+        : null;
 
     return Card(
       child: Padding(
@@ -77,7 +79,9 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
             informationRow(
               'Liquidation Price Drop',
               Text(
-                '-${numberFormatter(priceDropToLiquidation, 2)}%',
+                priceDropToLiquidation != null
+                    ? '-${numberFormatter(priceDropToLiquidation, 2)}%'
+                    : '—',
                 style: styles.monoSm.copyWith(color: colors.warning, fontWeight: FontWeight.bold),
               ),
             ),

--- a/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_card.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_card.dart
@@ -8,20 +8,16 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
   const AdaLeverageAboveRmrCard({
     super.key,
     required this.asset,
+    required this.collateralAsset,
     required this.interestRate,
-    required this.redemptionMarginRatio,
-    required this.maintenanceRatio,
-    required this.liquidationRatio,
     required this.assetPrice,
     required this.debtMintingFee,
     required this.collateralRatio,
   });
 
   final String asset;
+  final String collateralAsset;
   final double interestRate;
-  final double? redemptionMarginRatio;
-  final double? maintenanceRatio;
-  final double? liquidationRatio;
   final double assetPrice;
   final double debtMintingFee;
   final double collateralRatio;
@@ -30,6 +26,7 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = AppColorScheme.of(context);
     final styles = AppTextStyles.of(context);
+    final collateral = collateralLabel(collateralAsset);
 
     informationRow(String label, Widget info) => Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
@@ -42,17 +39,17 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
       ),
     );
 
-    calculatedAmount(double? amount) => Text(
-      amount != null ? '${numberFormatter(amount, 2)}%' : '—',
-      style: styles.monoSm.copyWith(color: colors.textPrimary),
+    valueText(String v, {Color? color}) => Text(
+      v,
+      style: styles.monoSm.copyWith(
+        color: color ?? colors.textPrimary,
+        fontWeight: FontWeight.w600,
+      ),
     );
 
     final cr = collateralRatio / 100;
     final leverage = 1 + 1 / cr;
     final liquidationLoss = -(1 - 1 / cr) * 100;
-    final priceDropToLiquidation = liquidationRatio != null
-        ? (1 - (liquidationRatio! / collateralRatio)) * 100
-        : null;
 
     return Card(
       child: Padding(
@@ -63,10 +60,10 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(asset, style: styles.cardTitle),
+                Text('$asset ($collateral Collateral)', style: styles.cardTitle),
                 Tooltip(
                   message:
-                      'This is the maximum theoretical \nleverage achievable based on the \nRedemption Margin Ratio.',
+                      'Maximum theoretical leverage\nbased on the Redemption Margin Ratio.',
                   child: AnimatedGradientText(
                     '${numberFormatter(leverage, 2)}x',
                     gradientColors: [colors.warning, colors.success],
@@ -77,27 +74,23 @@ class AdaLeverageAboveRmrCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             informationRow(
-              'Liquidation Price Drop',
-              Text(
-                priceDropToLiquidation != null
-                    ? '-${numberFormatter(priceDropToLiquidation, 2)}%'
-                    : '—',
-                style: styles.monoSm.copyWith(color: colors.warning, fontWeight: FontWeight.bold),
-              ),
-            ),
-            informationRow(
               'Liquidation Loss',
-              Text(
-                '${numberFormatter(liquidationLoss, 2)}%',
-                style: styles.monoSm.copyWith(color: colors.warning, fontWeight: FontWeight.bold),
-              ),
+              valueText('${numberFormatter(liquidationLoss, 2)}%', color: colors.warning),
             ),
             Divider(color: colors.border, height: 16),
-            informationRow('Interest Rate', calculatedAmount(interestRate)),
-            informationRow('Redemption Margin Ratio', calculatedAmount(redemptionMarginRatio)),
-            informationRow('Maintenance Ratio', calculatedAmount(maintenanceRatio)),
-            informationRow('Liquidation Ratio', calculatedAmount(liquidationRatio)),
-            informationRow('Minting Fee', calculatedAmount(debtMintingFee)),
+            informationRow('Collateral', valueText(collateral)),
+            informationRow(
+              'Price',
+              valueText('${numberFormatter(assetPrice, 4)} $collateral'),
+            ),
+            informationRow(
+              'Interest Rate',
+              valueText('${numberFormatter(interestRate, 2)}%'),
+            ),
+            informationRow(
+              'Minting Fee',
+              valueText('${numberFormatter(debtMintingFee, 2)}%'),
+            ),
           ],
         ),
       ),

--- a/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_content.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_content.dart
@@ -27,7 +27,7 @@ class _AdaLeverageAboveRmrContentState
     return AsyncBuilder(
       fetcher: () => sl<StrategyRepository>().getLeverageData(),
       builder: (leveragesData) {
-        final minCr = leveragesData.map((e) => e.rmr).min;
+        final minCr = leveragesData.map((e) => e.rmr).whereType<double>().minOrNull ?? 110.0;
         const maxCr = 500.0;
         _collateralRatio ??= minCr;
 
@@ -79,9 +79,9 @@ class _AdaLeverageAboveRmrContentState
                             liquidationRatio: data.liquidationRatio,
                             assetPrice: data.assetPrice,
                             debtMintingFee: data.debtMintingFee,
-                            collateralRatio: (_collateralRatio ?? minCr) > data.rmr
+                            collateralRatio: (_collateralRatio ?? minCr) > (data.rmr ?? minCr)
                                 ? (_collateralRatio ?? minCr)
-                                : data.rmr,
+                                : (data.rmr ?? minCr),
                           )
                               .animate()
                               .slideX(duration: 300.ms, curve: Curves.easeInOut)

--- a/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_content.dart
+++ b/lib/views/insights/strategy/ada_leverage_above_rmr/ada_leverage_above_rmr_content.dart
@@ -73,15 +73,11 @@ class _AdaLeverageAboveRmrContentState
                           width: itemWidth,
                           child: AdaLeverageAboveRmrCard(
                             asset: data.asset,
+                            collateralAsset: data.collateralAsset,
                             interestRate: data.interestRate,
-                            redemptionMarginRatio: data.rmr,
-                            maintenanceRatio: data.mcr,
-                            liquidationRatio: data.liquidationRatio,
                             assetPrice: data.assetPrice,
                             debtMintingFee: data.debtMintingFee,
-                            collateralRatio: (_collateralRatio ?? minCr) > (data.rmr ?? minCr)
-                                ? (_collateralRatio ?? minCr)
-                                : (data.rmr ?? minCr),
+                            collateralRatio: _collateralRatio ?? minCr,
                           )
                               .animate()
                               .slideX(duration: 300.ms, curve: Curves.easeInOut)

--- a/lib/widgets/amount_percentage_chart.dart
+++ b/lib/widgets/amount_percentage_chart.dart
@@ -28,24 +28,14 @@ List<AmountPercentageData> normalizeAmountPercentageData(
     if (inputIndex < inputList.length) {
       final percent = (inputList[inputIndex].percent * 100).round();
       if (percent == currentPercent) {
-        normalizedList.add(
-          AmountPercentageData(
-            currentPercent / 100.0,
-            inputList[inputIndex].amount,
-          ),
-        );
+        lastAmount = inputList[inputIndex].amount;
+        normalizedList.add(AmountPercentageData(currentPercent / 100.0, lastAmount));
         inputIndex++;
       } else {
-        if (currentPercent > percent) {
-          // throw Exception(
-          //   "normalizeAmountPercentageData: Input should have unique percents by interval 1",
-          // );
-        }
-        normalizedList.add(
-          AmountPercentageData(currentPercent / 100.0, lastAmount),
-        );
+        normalizedList.add(AmountPercentageData(currentPercent / 100.0, lastAmount));
       }
-      lastAmount = inputList[inputIndex].amount;
+    } else {
+      normalizedList.add(AmountPercentageData(currentPercent / 100.0, lastAmount));
     }
 
     currentPercent += 1;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -543,4 +543,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: "3.41.5"
+  flutter: "3.41.9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 
 environment:
   sdk: ^3.11.0
-  flutter: "3.41.5"
+  flutter: "3.41.9"
 
 dependencies:
   collection: ^1.19.1


### PR DESCRIPTION
Position Simulator

Collateral selector chips — only shown when asset has multiple collateral types (e.g. ADA + NIGHT)
All metrics (Liq. Price, Maintenance Price, RMR Price, CR%, scenario table, interest projection) use the selected collateral pair's ratios and price
Fixed interest rate bug: CollateralPair.interestRate is a decimal fraction — was incorrectly divided by 100 again in _InterestProjection
Removed AssetInterestRate dependency — rates now come directly from V3 assets
CDP Explorer

Size tier cards → custom PopupMenuButton dropdown with full stats per item, rounded corners, opens below/above based on space
Collateral filter dropdown added (only when NIGHT exists); table filters by collateral and resets to page 1
All previous V3 work (from prior sessions — SP multi-collateral, INDY staking fix, APR wiring, etc.) also included